### PR TITLE
Common LogMessagePrefxProvider and 

### DIFF
--- a/connectors/connector-api/pom.xml
+++ b/connectors/connector-api/pom.xml
@@ -1,13 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>tracee-context-logger-connector-api</artifactId>
+    <artifactId>contextlogger-connector-api</artifactId>
     <packaging>bundle</packaging>
 
     <parent>
         <groupId>io.tracee.contextlogger</groupId>
 		<artifactId>connector-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
 
     <name>connector-api</name>

--- a/connectors/http-connector/pom.xml
+++ b/connectors/http-connector/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.tracee.contextlogger</groupId>
 		<artifactId>connector-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
 
     <name>http-connector</name>
@@ -54,8 +54,7 @@
 
         <dependency>
             <groupId>io.tracee.contextlogger</groupId>
-            <artifactId>tracee-context-logger-connector-api</artifactId>
-            <version>${project.version}</version>
+            <artifactId>contextlogger-connector-api</artifactId>
         </dependency>
 
 		<dependency>

--- a/connectors/pom.xml
+++ b/connectors/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.tracee.contextlogger</groupId>
         <artifactId>contextlogger-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
 
     <name>connector-parent</name>

--- a/impl/pom.xml
+++ b/impl/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.tracee.contextlogger</groupId>
         <artifactId>contextlogger-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
 
     <name>contextlogger-impl</name>
@@ -50,14 +50,12 @@
 
         <dependency>
             <groupId>io.tracee.contextlogger</groupId>
-            <artifactId>tracee-context-logger-connector-api</artifactId>
-            <version>${project.version}</version>
+            <artifactId>contextlogger-connector-api</artifactId>
         </dependency>
 
         <dependency>
             <groupId>io.tracee.contextlogger</groupId>
             <artifactId>contextlogger-provider-api</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -70,6 +68,13 @@
 			<artifactId>gson</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+			<version>${apache.commonslang.version}</version>
+		</dependency>
+
+		<!-- provided dependencies -->
         <dependency>
             <groupId>org.jboss.spec.javax.servlet</groupId>
             <artifactId>jboss-servlet-api_3.0_spec</artifactId>
@@ -77,16 +82,12 @@
             <scope>provided</scope>
         </dependency>
 
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.2.1</version>
-        </dependency>
+
 
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-            <version>1.7.4</version>
+            <version>${aspectj.version}</version>
             <scope>provided</scope>
         </dependency>
 
@@ -106,7 +107,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <scope>test</scope>
+			<scope>test</scope>
         </dependency>
 
         <dependency>
@@ -117,29 +118,21 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.3</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.reflections</groupId>
             <artifactId>reflections</artifactId>
-            <version>0.9.9-RC1</version>
-            <scope>test</scope>
         </dependency>
 
     </dependencies>

--- a/impl/src/main/java/io/tracee/contextlogger/MessagePrefixProvider.java
+++ b/impl/src/main/java/io/tracee/contextlogger/MessagePrefixProvider.java
@@ -1,0 +1,23 @@
+package io.tracee.contextlogger;
+
+import io.tracee.contextlogger.api.internal.MessageLogLevel;
+
+/**
+ * Provides a strictly formatted log message prefix.
+ */
+public final class MessagePrefixProvider {
+
+    public static final MessageLogLevel DEFAULT_LEVEL = MessageLogLevel.INFO;
+
+    static final String JSON_PREFIXED_MESSAGE = "TRACEE_CL_{1}[{2}]  : ";
+
+    public static String provideLogMessagePrefix(final MessageLogLevel logLevel, final String type) {
+        String prefix = JSON_PREFIXED_MESSAGE.replace("{1}", logLevel != null ? logLevel.getLevel() : DEFAULT_LEVEL.getLevel());
+        prefix = prefix.replace("{2}", type != null ? type : "");
+        return prefix;
+    }
+
+    public static String provideLogMessagePrefix(final MessageLogLevel logLevel, final Class type) {
+        return provideLogMessagePrefix(logLevel, type != null ? type.getSimpleName() : null);
+    }
+}

--- a/impl/src/main/java/io/tracee/contextlogger/api/internal/MessageLogLevel.java
+++ b/impl/src/main/java/io/tracee/contextlogger/api/internal/MessageLogLevel.java
@@ -1,0 +1,72 @@
+package io.tracee.contextlogger.api.internal;
+
+import io.tracee.Tracee;
+import io.tracee.TraceeLogger;
+
+/**
+ * Enum for defining log level for log output.
+ */
+public enum MessageLogLevel {
+
+    ERROR() {
+
+        @Override
+        public void log(final TraceeLogger logger, final String logMessage) {
+            logger.error(logMessage);
+        }
+    },
+    WARNING() {
+
+        @Override
+        public void log(final TraceeLogger logger, final String logMessage) {
+            logger.warn(logMessage);
+        }
+    },
+    INFO() {
+
+        @Override
+        public void log(final TraceeLogger logger, final String logMessage) {
+            logger.info(logMessage);
+        }
+    },
+    DEBUG() {
+
+        @Override
+        public void log(final TraceeLogger logger, final String logMessage) {
+            logger.debug(logMessage);
+        }
+    };
+
+    public String getLevel() {
+        return this.name();
+    }
+
+    /**
+     * Writes the log message with this type.
+     *
+     * @param logMessage the log message to write
+     */
+    public void writeLogMessage(final String logMessage) {
+        this.writeLogMessage(this.getClass(), logMessage);
+    }
+
+    /**
+     * Writes a given log message.
+     *
+     * @param clazz the type used to get the logger for
+     * @param logMessage the log message to write
+     */
+    public void writeLogMessage(final Class clazz, final String logMessage) {
+        TraceeLogger logger = Tracee.getBackend().getLoggerFactory().getLogger(clazz);
+
+    }
+
+    /**
+     * Abstract method to provide different log level imlementations.
+     *
+     * @param logger the TraceeLogger to use
+     * @param logMessage the log message to write
+     */
+    public abstract void log(TraceeLogger logger, final String logMessage);
+
+}

--- a/impl/src/test/java/io/tracee/contextlogger/MessagePrefixProviderTest.java
+++ b/impl/src/test/java/io/tracee/contextlogger/MessagePrefixProviderTest.java
@@ -1,0 +1,41 @@
+package io.tracee.contextlogger;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import io.tracee.contextlogger.api.internal.MessageLogLevel;
+
+/**
+ * Test class for {@link io.tracee.contextlogger.MessagePrefixProvider}.
+ */
+public class MessagePrefixProviderTest {
+
+    @Test
+    public void provide_prefix_with_info_log_level() {
+        MessageLogLevel givenLogLevel = MessageLogLevel.INFO;
+
+        String prefix = MessagePrefixProvider.provideLogMessagePrefix(givenLogLevel, MessagePrefixProviderTest.class);
+        MatcherAssert.assertThat(prefix, Matchers.is("TRACEE_CL_" + givenLogLevel.getLevel() + "[MessagePrefixProviderTest]  : "));
+
+    }
+
+    @Test
+    public void provide_prefix_with_default_log_level() {
+        MessageLogLevel givenLogLevel = null;
+
+        String prefix = MessagePrefixProvider.provideLogMessagePrefix(givenLogLevel, MessagePrefixProviderTest.class);
+        MatcherAssert.assertThat(prefix, Matchers.is("TRACEE_CL_" + MessagePrefixProvider.DEFAULT_LEVEL.getLevel() + "[MessagePrefixProviderTest]  : "));
+
+    }
+
+    @Test
+    public void provide_prefix_with_default_log_level_and_no_type() {
+        MessageLogLevel givenLogLevel = null;
+
+        String prefix = MessagePrefixProvider.provideLogMessagePrefix(givenLogLevel, (Class)null);
+        MatcherAssert.assertThat(prefix, Matchers.is("TRACEE_CL_" + MessagePrefixProvider.DEFAULT_LEVEL.getLevel() + "[]  : "));
+
+    }
+
+}

--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.tracee.contextlogger</groupId>
         <artifactId>contextlogger-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
 
     <name>contextlogger-integration-test</name>
@@ -29,12 +29,10 @@
 		<dependency>
 			<groupId>io.tracee.contextlogger</groupId>
 			<artifactId>contextlogger-provider-api</artifactId>
-			<version>${project.version}</version>
 		</dependency>
         <dependency>
             <groupId>io.tracee.contextlogger</groupId>
             <artifactId>contextlogger-impl</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <!-- dependecies for unittests -->

--- a/javaee/pom.xml
+++ b/javaee/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.tracee.contextlogger</groupId>
         <artifactId>contextlogger-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
 
     <name>contextlogger-javaee</name>
@@ -17,7 +17,6 @@
         <dependency>
             <groupId>io.tracee.contextlogger</groupId>
             <artifactId>contextlogger-impl</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>
@@ -25,6 +24,7 @@
             <groupId>io.tracee</groupId>
         </dependency>
 
+		<!-- provided dependencies -->
         <dependency>
             <groupId>javax.ejb</groupId>
             <artifactId>ejb-api</artifactId>
@@ -35,6 +35,8 @@
             <artifactId>jms-api</artifactId>
         </dependency>
 
+
+		<!-- unit test dependencies-->
 		<dependency>
 			<groupId>io.tracee</groupId>
 			<artifactId>tracee-testhelper</artifactId>

--- a/javaee/src/main/java/io/tracee/contextlogger/javaee/TraceeErrorContextLoggingInterceptor.java
+++ b/javaee/src/main/java/io/tracee/contextlogger/javaee/TraceeErrorContextLoggingInterceptor.java
@@ -3,9 +3,11 @@ package io.tracee.contextlogger.javaee;
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.InvocationContext;
 
+import io.tracee.contextlogger.MessagePrefixProvider;
 import io.tracee.contextlogger.TraceeContextLogger;
 import io.tracee.contextlogger.api.ErrorMessage;
 import io.tracee.contextlogger.api.ImplicitContext;
+import io.tracee.contextlogger.api.internal.MessageLogLevel;
 import io.tracee.contextlogger.contextprovider.tracee.TraceeMessage;
 
 /**
@@ -14,8 +16,6 @@ import io.tracee.contextlogger.contextprovider.tracee.TraceeMessage;
  * Created by Tobias Gindler, holisticon AG on 13.03.14.
  */
 public class TraceeErrorContextLoggingInterceptor {
-
-    static final String JSON_PREFIXED_MESSAGE = "TRACEE EJB INTERCEPTOR CONTEXT LOGGING LISTENER : ";
 
     @SuppressWarnings("unused")
     public TraceeErrorContextLoggingInterceptor() {
@@ -33,12 +33,14 @@ public class TraceeErrorContextLoggingInterceptor {
 
             // now log context informations
             if (errorMessage == null) {
-                TraceeContextLogger.createDefault().logJsonWithPrefixedMessage(JSON_PREFIXED_MESSAGE, ImplicitContext.COMMON, ImplicitContext.TRACEE, ctx,
-                        e);
+                TraceeContextLogger.createDefault().logJsonWithPrefixedMessage(
+                        MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, TraceeErrorContextLoggingInterceptor.class),
+                        ImplicitContext.COMMON, ImplicitContext.TRACEE, ctx, e);
             }
             else {
-                TraceeContextLogger.createDefault().logJsonWithPrefixedMessage(JSON_PREFIXED_MESSAGE, TraceeMessage.wrap(errorMessage.value()),
-                        ImplicitContext.COMMON, ImplicitContext.TRACEE, ctx, e);
+                TraceeContextLogger.createDefault().logJsonWithPrefixedMessage(
+                        MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, TraceeErrorContextLoggingInterceptor.class),
+                        TraceeMessage.wrap(errorMessage.value()), ImplicitContext.COMMON, ImplicitContext.TRACEE, ctx, e);
             }
             throw e;
         }

--- a/javaee/src/test/java/io/tracee/contextlogger/javaee/TraceeErrorContextLoggingInterceptorTest.java
+++ b/javaee/src/test/java/io/tracee/contextlogger/javaee/TraceeErrorContextLoggingInterceptorTest.java
@@ -1,15 +1,10 @@
 package io.tracee.contextlogger.javaee;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 import javax.interceptor.InvocationContext;
@@ -21,10 +16,12 @@ import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+import io.tracee.contextlogger.MessagePrefixProvider;
 import io.tracee.contextlogger.TraceeContextLogger;
 import io.tracee.contextlogger.api.ContextLogger;
 import io.tracee.contextlogger.api.ErrorMessage;
 import io.tracee.contextlogger.api.ImplicitContext;
+import io.tracee.contextlogger.api.internal.MessageLogLevel;
 import io.tracee.contextlogger.contextprovider.tracee.TraceeMessage;
 
 /**
@@ -32,8 +29,10 @@ import io.tracee.contextlogger.contextprovider.tracee.TraceeMessage;
  * Created by Tobias Gindler on 19.06.14.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ TraceeContextLogger.class, TraceeMessage.class })
+@PrepareForTest({ TraceeContextLogger.class, TraceeMessage.class, MessagePrefixProvider.class })
 public class TraceeErrorContextLoggingInterceptorTest {
+
+    private final static String LOG_MESSAGE_PREFIX = "XX";
 
     public static final String ERROR_MESSAGE = "ABC";
 
@@ -54,6 +53,11 @@ public class TraceeErrorContextLoggingInterceptorTest {
         when(TraceeContextLogger.createDefault()).thenReturn(contextLogger);
         mockStatic(TraceeMessage.class);
         when(TraceeMessage.wrap(ERROR_MESSAGE)).thenReturn(traceeMessage);
+
+        // mock log message prefix creation
+        mockStatic(MessagePrefixProvider.class);
+        when(MessagePrefixProvider.provideLogMessagePrefix(Mockito.any(MessageLogLevel.class), Mockito.any(String.class))).thenReturn(LOG_MESSAGE_PREFIX);
+        when(MessagePrefixProvider.provideLogMessagePrefix(Mockito.any(MessageLogLevel.class), Mockito.any(Class.class))).thenReturn(LOG_MESSAGE_PREFIX);
     }
 
     @Test
@@ -83,8 +87,8 @@ public class TraceeErrorContextLoggingInterceptorTest {
         }
         catch (Exception e) {
             verify(invocationContext).proceed();
-            verify(contextLogger).logJsonWithPrefixedMessage(TraceeErrorContextLoggingInterceptor.JSON_PREFIXED_MESSAGE, ImplicitContext.COMMON,
-                    ImplicitContext.TRACEE, invocationContext, exception);
+            verify(contextLogger).logJsonWithPrefixedMessage(LOG_MESSAGE_PREFIX, ImplicitContext.COMMON, ImplicitContext.TRACEE, invocationContext,
+                    exception);
             throw e;
         }
     }
@@ -103,8 +107,8 @@ public class TraceeErrorContextLoggingInterceptorTest {
         }
         catch (Exception e) {
             verify(invocationContext).proceed();
-            verify(contextLogger).logJsonWithPrefixedMessage(TraceeErrorContextLoggingInterceptor.JSON_PREFIXED_MESSAGE, traceeMessage,
-                    ImplicitContext.COMMON, ImplicitContext.TRACEE, invocationContext, exception);
+            verify(contextLogger).logJsonWithPrefixedMessage(LOG_MESSAGE_PREFIX, traceeMessage, ImplicitContext.COMMON, ImplicitContext.TRACEE,
+                    invocationContext, exception);
             throw e;
         }
     }

--- a/jaxws/pom.xml
+++ b/jaxws/pom.xml
@@ -7,13 +7,15 @@
     <parent>
         <groupId>io.tracee.contextlogger</groupId>
         <artifactId>contextlogger-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
 
     <name>contextlogger-jaxws</name>
     <description>Please refer to https://github.com/tracee/contextlogger.</description>
 
     <dependencies>
+
+		<!-- tracee dependencies -->
         <dependency>
             <artifactId>tracee-api</artifactId>
             <groupId>io.tracee</groupId>
@@ -24,21 +26,24 @@
 			<artifactId>tracee-jaxws</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>io.tracee.contextlogger</groupId>
+			<artifactId>contextlogger-impl</artifactId>
+		</dependency>
+
+
+		<!-- external provided dependencies -->
         <dependency>
             <groupId>javax.ejb</groupId>
             <artifactId>ejb-api</artifactId>
         </dependency>
 
-		<dependency>
-            <groupId>io.tracee.contextlogger</groupId>
-			<artifactId>contextlogger-impl</artifactId>
-			<version>${project.version}</version>
-		</dependency>
 
-        <dependency>
-            <groupId>io.tracee.backend</groupId>
-            <artifactId>tracee-slf4j</artifactId>
-        </dependency>
+		<!-- unit test dependencies -->
+		<dependency>
+			<groupId>io.tracee.backend</groupId>
+			<artifactId>tracee-slf4j</artifactId>
+		</dependency>
 
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -55,10 +60,12 @@
 			<groupId>io.tracee</groupId>
 			<artifactId>tracee-testhelper</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-api-mockito</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>io.tracee.contextlogger</groupId>
 	<artifactId>contextlogger-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.6.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>tracee-contextlogger</name>
@@ -26,7 +26,7 @@
         <groupId>org.sonatype.oss</groupId>
         <artifactId>oss-parent</artifactId>
         <version>9</version>
-    
+
     </parent>
 
     <organization>
@@ -73,6 +73,10 @@
 		<logback.version>0.9.30</logback.version>
 		<gson.version>2.2.4</gson.version>
 		<spring.version>3.0.7.RELEASE</spring.version>
+		<jodatime.version>2.3</jodatime.version>
+		<reclections.version>0.9.9-RC1</reclections.version>
+		<aspectj.version>1.7.4</aspectj.version>
+		<apache.commonslang.version>3.2.1</apache.commonslang.version>
 	</properties>
 
 	<build>
@@ -251,22 +255,48 @@
 			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-library</artifactId>
 			<version>${hamcrest.version}</version>
 			<scope>test</scope>
 		</dependency>
+
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>
 			<version>${mockito.version}</version>
 			<scope>test</scope>
 		</dependency>
+
+
+
 	</dependencies>
 
 	<dependencyManagement>
 		<dependencies>
+
+			<!-- internal -->
+			<dependency>
+				<groupId>io.tracee.contextlogger</groupId>
+				<artifactId>contextlogger-impl</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>io.tracee.contextlogger</groupId>
+				<artifactId>contextlogger-provider-api</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>io.tracee.contextlogger</groupId>
+				<artifactId>contextlogger-connector-api</artifactId>
+				<version>${project.version}</version>
+			</dependency>
+
+
 			<!-- Tracee Dependencies -->
 			<dependency>
 				<groupId>io.tracee</groupId>
@@ -291,6 +321,7 @@
 				<scope>test</scope>
 			</dependency>
 
+			<!-- external dependencies -->
 			<dependency>
 				<groupId>ch.qos.logback</groupId>
 				<artifactId>logback-classic</artifactId>
@@ -303,7 +334,7 @@
 				<version>${gson.version}</version>
 			</dependency>
 
-			<!-- Provided dependencies -->
+			<!-- external provided dependencies -->
 			<dependency>
 				<groupId>org.slf4j</groupId>
 				<artifactId>slf4j-api</artifactId>
@@ -346,6 +377,20 @@
 						<groupId>org.mockito</groupId>
 					</exclusion>
 				</exclusions>
+			</dependency>
+
+			<dependency>
+				<groupId>joda-time</groupId>
+				<artifactId>joda-time</artifactId>
+				<version>${jodatime.version}</version>
+				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>org.reflections</groupId>
+				<artifactId>reflections</artifactId>
+				<version>${reclections.version}</version>
+				<scope>test</scope>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/provider-api/pom.xml
+++ b/provider-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.tracee.contextlogger</groupId>
         <artifactId>contextlogger-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
 
     <name>contextlogger-provider-api</name>

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -7,30 +7,36 @@
     <parent>
         <groupId>io.tracee.contextlogger</groupId>
         <artifactId>contextlogger-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
 
     <name>contextlogger-servlet</name>
     <description>Please refer to https://github.com/tracee/contextlogger.</description>
 
     <dependencies>
+
         <dependency>
             <groupId>io.tracee.contextlogger</groupId>
             <artifactId>contextlogger-impl</artifactId>
-            <version>${project.version}</version>
         </dependency>
+
+		<!-- provided external dependencies-->
         <dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>servlet-api</artifactId>
         </dependency>
+
+		<!-- unit test dependencies -->
 		<dependency>
 			<groupId>io.tracee</groupId>
 			<artifactId>tracee-testhelper</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-module-junit4</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.powermock</groupId>
 			<artifactId>powermock-api-mockito</artifactId>

--- a/servlet/src/main/java/io/tracee/contextlogger/servlet/TraceeErrorLoggingFilter.java
+++ b/servlet/src/main/java/io/tracee/contextlogger/servlet/TraceeErrorLoggingFilter.java
@@ -2,20 +2,20 @@ package io.tracee.contextlogger.servlet;
 
 import java.io.IOException;
 
-import io.tracee.contextlogger.TraceeContextLogger;
-import io.tracee.contextlogger.api.ImplicitContext;
-
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import io.tracee.contextlogger.MessagePrefixProvider;
+import io.tracee.contextlogger.TraceeContextLogger;
+import io.tracee.contextlogger.api.ImplicitContext;
+import io.tracee.contextlogger.api.internal.MessageLogLevel;
 
 /**
  * Servlet filter to detect uncaught exceptions and to provide some contextual error logs.
  * Created by Tobias Gindler, holisticon AG on 11.12.13.
  */
 public class TraceeErrorLoggingFilter implements Filter {
-
-    static final String LOGGING_PREFIX_MESSAGE = "TRACEE SERVLET ERROR CONTEXT LOGGING LISTENER  : ";
 
     @Override
     public final void init(FilterConfig filterConfig) throws ServletException {
@@ -48,8 +48,9 @@ public class TraceeErrorLoggingFilter implements Filter {
 
     private void handleHttpServletRequest(HttpServletRequest servletRequest, HttpServletResponse servletResponse, Exception e) {
 
-        TraceeContextLogger.createDefault().logJsonWithPrefixedMessage(LOGGING_PREFIX_MESSAGE, ImplicitContext.COMMON, ImplicitContext.TRACEE,
-                servletRequest, servletResponse, servletRequest.getSession(false), e);
+        TraceeContextLogger.createDefault().logJsonWithPrefixedMessage(
+                MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, TraceeErrorLoggingFilter.class), ImplicitContext.COMMON,
+                ImplicitContext.TRACEE, servletRequest, servletResponse, servletRequest.getSession(false), e);
 
     }
 

--- a/watchdog/pom.xml
+++ b/watchdog/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.tracee.contextlogger</groupId>
         <artifactId>contextlogger-parent</artifactId>
-        <version>0.1.0-SNAPSHOT</version>
+        <version>0.6.0-SNAPSHOT</version>
     </parent>
 
     <name>contextlogger-watchdog</name>
@@ -50,20 +50,19 @@
         <dependency>
             <groupId>io.tracee.contextlogger</groupId>
             <artifactId>contextlogger-impl</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
 
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-            <version>1.7.4</version>
+            <version>${aspectj.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjweaver</artifactId>
-            <version>1.7.4</version>
+            <version>${aspectj.version}</version>
         </dependency>
 
 
@@ -87,15 +86,11 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito</artifactId>
-            <version>${powermock.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/watchdog/src/main/java/io/tracee/contextlogger/watchdog/WatchdogAspect.java
+++ b/watchdog/src/main/java/io/tracee/contextlogger/watchdog/WatchdogAspect.java
@@ -1,17 +1,20 @@
 package io.tracee.contextlogger.watchdog;
 
-import io.tracee.Tracee;
-import io.tracee.TraceeBackend;
-import io.tracee.contextlogger.TraceeContextLogger;
-import io.tracee.contextlogger.api.ErrorMessage;
-import io.tracee.contextlogger.api.ImplicitContext;
-import io.tracee.contextlogger.contextprovider.aspectj.WatchdogDataWrapper;
-import io.tracee.contextlogger.contextprovider.tracee.TraceeMessage;
-import io.tracee.contextlogger.watchdog.util.WatchdogUtils;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+
+import io.tracee.Tracee;
+import io.tracee.TraceeBackend;
+import io.tracee.contextlogger.MessagePrefixProvider;
+import io.tracee.contextlogger.TraceeContextLogger;
+import io.tracee.contextlogger.api.ErrorMessage;
+import io.tracee.contextlogger.api.ImplicitContext;
+import io.tracee.contextlogger.api.internal.MessageLogLevel;
+import io.tracee.contextlogger.contextprovider.aspectj.WatchdogDataWrapper;
+import io.tracee.contextlogger.contextprovider.tracee.TraceeMessage;
+import io.tracee.contextlogger.watchdog.util.WatchdogUtils;
 
 /**
  * Watchdog Assert class.
@@ -56,7 +59,8 @@ public class WatchdogAspect {
 
         try {
             return proceedingJoinPoint.proceed();
-        } catch (final Throwable e) {
+        }
+        catch (final Throwable e) {
 
             // check if watchdog processing is flagged as active
             if (active) {
@@ -78,7 +82,8 @@ public class WatchdogAspect {
 
                     }
 
-                } catch (Throwable error) {
+                }
+                catch (Throwable error) {
                     // will be ignored
                     traceeBackend.getLoggerFactory().getLogger(WatchdogAspect.class).error("error", error);
                 }
@@ -92,9 +97,9 @@ public class WatchdogAspect {
     /**
      * Sends the error reports to all connectors.
      *
-     * @param traceeBackend       the tracee backend
+     * @param traceeBackend the tracee backend
      * @param proceedingJoinPoint the aspectj calling context
-     * @param annotatedId         the id defined in the watchdog annotation
+     * @param annotatedId the id defined in the watchdog annotation
      */
     void sendErrorReportToConnectors(TraceeBackend traceeBackend, ProceedingJoinPoint proceedingJoinPoint, String annotatedId, Throwable e) {
 
@@ -102,12 +107,14 @@ public class WatchdogAspect {
         ErrorMessage errorMessage = WatchdogUtils.getErrorMessageAnnotation(proceedingJoinPoint);
 
         if (errorMessage == null) {
-            TraceeContextLogger.createDefault().logJsonWithPrefixedMessage("TRACEE WATCHDOG ERROR CONTEXT LISTENER :", ImplicitContext.COMMON,
-                    ImplicitContext.TRACEE, WatchdogDataWrapper.wrap(annotatedId, proceedingJoinPoint), e);
-        } else {
-            TraceeContextLogger.createDefault().logJsonWithPrefixedMessage("TRACEE WATCHDOG ERROR CONTEXT LISTENER :",
-                    TraceeMessage.wrap(errorMessage.value()), ImplicitContext.COMMON, ImplicitContext.TRACEE,
+            TraceeContextLogger.createDefault().logJsonWithPrefixedMessage(
+                    MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, Watchdog.class), ImplicitContext.COMMON, ImplicitContext.TRACEE,
                     WatchdogDataWrapper.wrap(annotatedId, proceedingJoinPoint), e);
+        }
+        else {
+            TraceeContextLogger.createDefault().logJsonWithPrefixedMessage(
+                    MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, Watchdog.class), TraceeMessage.wrap(errorMessage.value()),
+                    ImplicitContext.COMMON, ImplicitContext.TRACEE, WatchdogDataWrapper.wrap(annotatedId, proceedingJoinPoint), e);
         }
     }
 


### PR DESCRIPTION
I think  it is misleading to go back to version 0.1.0-SNAPSHOT because before the contextlogger was extracted from tracee project we used already version 0.5.0-SNAPSHOT. Therefore we should go to version 0.6.0-SNAPSHOT to avoid misleading versioning (even if some artifact ids have changed).

Common LogMessagePrefixProvider will close issue #2.