### PR TITLE
[#46, #22] Refactorings

### DIFF
--- a/contextprovider/annotationprocessor/src/main/java/io/tracee/contextlogger/contextprovider/api/TraceeContextLoggerAbstractProcessor.java
+++ b/contextprovider/annotationprocessor/src/main/java/io/tracee/contextlogger/contextprovider/api/TraceeContextLoggerAbstractProcessor.java
@@ -6,9 +6,6 @@ import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.tools.Diagnostic;
@@ -24,18 +21,12 @@ import java.util.Map;
  */
 public abstract class TraceeContextLoggerAbstractProcessor extends AbstractProcessor {
 
-	private static Map<String, DeclaredType> cachedParentTypes = new HashMap<String, DeclaredType>();
 	private static Map<String, FileObjectWrapper> traceeProfileProperties = new HashMap<String, FileObjectWrapper>();
 
 	protected Messager messager;
 	protected Types typeUtils;
 	protected Elements elementUtils;
 	protected Filer filer;
-
-	protected TypeElement COLLECTION;
-	protected TypeElement MAP;
-	protected TypeElement VOID;
-	protected WildcardType WILDCARD_TYPE_NULL;
 
 	public static class FileObjectWrapper {
 		private final FileObject fileObject;
@@ -81,7 +72,7 @@ public abstract class TraceeContextLoggerAbstractProcessor extends AbstractProce
 	/**
 	 * Central method to get cached FileObjectWrapper. Creates new FileObjectWrapper if it can't be found
 	 */
-	protected static synchronized FileObjectWrapper getOrcreateProfileProperties(final Filer filer, String fileName) throws IOException {
+	protected static synchronized FileObjectWrapper getOrCreateProfileProperties(final Filer filer, String fileName) throws IOException {
 
 		FileObjectWrapper fileObject = traceeProfileProperties.get(fileName);
 
@@ -95,5 +86,8 @@ public abstract class TraceeContextLoggerAbstractProcessor extends AbstractProce
 
 	}
 
+	protected static void clearCache() {
+		traceeProfileProperties.clear();
+	}
 
 }

--- a/contextprovider/annotationprocessor/src/main/java/io/tracee/contextlogger/contextprovider/api/TraceeContextProviderMethodProcessor.java
+++ b/contextprovider/annotationprocessor/src/main/java/io/tracee/contextlogger/contextprovider/api/TraceeContextProviderMethodProcessor.java
@@ -76,7 +76,7 @@ public class TraceeContextProviderMethodProcessor extends TraceeContextLoggerAbs
 
 	protected void writeToPropertyFile(Profile profile, TypeElement parentElement, Element element, boolean value) throws IOException {
 
-		FileObjectWrapper fileObject = getOrcreateProfileProperties(filer, profile.getFilename());
+		FileObjectWrapper fileObject = getOrCreateProfileProperties(filer, profile.getFilename());
 
 		String fieldName = GetterUtilities.getFieldName(element.getSimpleName().toString());
 		if (fieldName == null) {

--- a/contextprovider/annotationprocessor/src/main/java/io/tracee/contextlogger/contextprovider/api/TraceeContextProviderMethodProcessor.java
+++ b/contextprovider/annotationprocessor/src/main/java/io/tracee/contextlogger/contextprovider/api/TraceeContextProviderMethodProcessor.java
@@ -48,7 +48,7 @@ public class TraceeContextProviderMethodProcessor extends TraceeContextLoggerAbs
 			try {
 
 				// write entry for fields
-				ProfileSettings annotation = element.getAnnotation(ProfileSettings.class);
+				ProfileConfig annotation = element.getAnnotation(ProfileConfig.class);
 
 				boolean basicProfileSettings = annotation != null && annotation.basic();
 				boolean enhancedProfileSettings = annotation != null && annotation.enhanced();

--- a/contextprovider/annotationprocessor/src/main/java/io/tracee/contextlogger/contextprovider/api/TraceeContextProviderProcessor.java
+++ b/contextprovider/annotationprocessor/src/main/java/io/tracee/contextlogger/contextprovider/api/TraceeContextProviderProcessor.java
@@ -46,7 +46,7 @@ public class TraceeContextProviderProcessor extends TraceeContextLoggerAbstractT
 			// Write class profile properties
 			try {
 
-				ProfileSettings annotation = element.getAnnotation(ProfileSettings.class);
+				ProfileConfig annotation = element.getAnnotation(ProfileConfig.class);
 
 				boolean basicProfileSettings = annotation != null && annotation.basic();
 				boolean enhancedProfileSettings = annotation != null && annotation.enhanced();

--- a/contextprovider/annotationprocessor/src/main/java/io/tracee/contextlogger/contextprovider/api/TraceeContextProviderProcessor.java
+++ b/contextprovider/annotationprocessor/src/main/java/io/tracee/contextlogger/contextprovider/api/TraceeContextProviderProcessor.java
@@ -76,7 +76,7 @@ public class TraceeContextProviderProcessor extends TraceeContextLoggerAbstractT
 
 	protected void writeToPropertyFile(Profile profile, TypeElement element, boolean value) throws IOException {
 
-		FileObjectWrapper fileObject = getOrcreateProfileProperties(filer, profile.getFilename());
+		FileObjectWrapper fileObject = getOrCreateProfileProperties(filer, profile.getFilename());
 		fileObject.append(element.getQualifiedName() + "=" + value + "\n");
 
 	}

--- a/contextprovider/annotationprocessor/src/test/java/io/tracee/contextlogger/contextprovider/api/TraceeContextLoggerAbstractProcessorTest.java
+++ b/contextprovider/annotationprocessor/src/test/java/io/tracee/contextlogger/contextprovider/api/TraceeContextLoggerAbstractProcessorTest.java
@@ -1,0 +1,85 @@
+package io.tracee.contextlogger.contextprovider.api;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import javax.annotation.processing.Filer;
+import javax.lang.model.element.Element;
+import javax.tools.FileObject;
+import javax.tools.StandardLocation;
+import java.io.IOException;
+import java.io.Writer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit test for {@link TraceeContextLoggerAbstractProcessor}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class TraceeContextLoggerAbstractProcessorTest {
+
+	static final String GIVEN_FILE_NAME = "XXX";
+
+	@Mock
+	Filer filer;
+
+	@Before
+	public void init() {
+		TraceeContextLoggerAbstractProcessor.clearCache();
+	}
+
+	@Test
+	public void FileObjectWrapper_instantiationAndAppendTest() throws IOException {
+
+		// prepare test
+		FileObject fileObject = mock(FileObject.class);
+		Writer writer = mock(Writer.class);
+		when(fileObject.openWriter()).thenReturn(writer);
+
+		TraceeContextLoggerAbstractProcessor.FileObjectWrapper fowUnit = new TraceeContextLoggerAbstractProcessor.FileObjectWrapper(fileObject);
+
+		fowUnit.append("TEST");
+
+		verify(fileObject).openWriter();
+		verify(writer).append("TEST");
+		verify(writer).flush();
+
+	}
+
+	@Test
+	public void getOrcreateProfileProperties_createNewFileObject() throws IOException {
+
+		FileObject fileObject = mock(FileObject.class);
+		Writer writer = mock(Writer.class);
+
+		when(filer.createResource(eq(StandardLocation.SOURCE_OUTPUT), eq(""), eq(GIVEN_FILE_NAME), isNull(Element.class))).thenReturn(fileObject);
+
+		assertThat(TraceeContextLoggerAbstractProcessor.getOrCreateProfileProperties(filer, GIVEN_FILE_NAME), notNullValue());
+		verify(filer, times(1)).createResource(StandardLocation.SOURCE_OUTPUT, "", GIVEN_FILE_NAME, null);
+
+	}
+
+	@Test
+	public void getOrcreateProfileProperties_getCachedFileObject() throws IOException {
+
+		// fill cache
+		getOrcreateProfileProperties_createNewFileObject();
+
+		// get it for the second time
+		assertThat(TraceeContextLoggerAbstractProcessor.getOrCreateProfileProperties(filer, GIVEN_FILE_NAME), notNullValue());
+		verify(filer, times(1)).createResource(StandardLocation.SOURCE_OUTPUT, "", GIVEN_FILE_NAME, null);
+
+	}
+
+
+}

--- a/contextprovider/annotationprocessor/src/test/java/io/tracee/contextlogger/contextprovider/api/TraceeContextProviderMethodProcessorTest.java
+++ b/contextprovider/annotationprocessor/src/test/java/io/tracee/contextlogger/contextprovider/api/TraceeContextProviderMethodProcessorTest.java
@@ -64,11 +64,11 @@ public class TraceeContextProviderMethodProcessorTest {
 		when(element.getEnclosingElement()).thenReturn(parentElement);
 
 		// prepare profile settings
-		ProfileSettings profileSettings = mock(ProfileSettings.class);
-		when(profileSettings.basic()).thenReturn(true);
-		when(profileSettings.enhanced()).thenReturn(true);
-		when(profileSettings.full()).thenReturn(true);
-		when(element.getAnnotation(ProfileSettings.class)).thenReturn(profileSettings);
+		ProfileConfig profileConfig = mock(ProfileConfig.class);
+		when(profileConfig.basic()).thenReturn(true);
+		when(profileConfig.enhanced()).thenReturn(true);
+		when(profileConfig.full()).thenReturn(true);
+		when(element.getAnnotation(ProfileConfig.class)).thenReturn(profileConfig);
 
 		// provide elements annotated with Flatten annotation
 		Set<Element> set = new HashSet<Element>();
@@ -110,8 +110,8 @@ public class TraceeContextProviderMethodProcessorTest {
 		when(element.getEnclosingElement()).thenReturn(parentElement);
 
 		// prepare profile settings
-		ProfileSettings profileSettings = null;
-		when(element.getAnnotation(ProfileSettings.class)).thenReturn(profileSettings);
+		ProfileConfig profileConfig = null;
+		when(element.getAnnotation(ProfileConfig.class)).thenReturn(profileConfig);
 
 		// provide elements annotated with Flatten annotation
 		Set<Element> set = new HashSet<Element>();
@@ -154,11 +154,11 @@ public class TraceeContextProviderMethodProcessorTest {
 		when(element.getEnclosingElement()).thenReturn(parentElement);
 
 		// prepare profile settings
-		ProfileSettings profileSettings = mock(ProfileSettings.class);
-		when(profileSettings.basic()).thenReturn(true);
-		when(profileSettings.enhanced()).thenReturn(true);
-		when(profileSettings.full()).thenReturn(true);
-		when(element.getAnnotation(ProfileSettings.class)).thenReturn(profileSettings);
+		ProfileConfig profileConfig = mock(ProfileConfig.class);
+		when(profileConfig.basic()).thenReturn(true);
+		when(profileConfig.enhanced()).thenReturn(true);
+		when(profileConfig.full()).thenReturn(true);
+		when(element.getAnnotation(ProfileConfig.class)).thenReturn(profileConfig);
 
 		// provide elements annotated with Flatten annotation
 		Set<Element> set = new HashSet<Element>();
@@ -200,11 +200,11 @@ public class TraceeContextProviderMethodProcessorTest {
 		when(element.getEnclosingElement()).thenReturn(parentElement);
 
 		// prepare profile settings
-		ProfileSettings profileSettings = mock(ProfileSettings.class);
-		when(profileSettings.basic()).thenReturn(true);
-		when(profileSettings.enhanced()).thenReturn(true);
-		when(profileSettings.full()).thenReturn(true);
-		when(element.getAnnotation(ProfileSettings.class)).thenReturn(profileSettings);
+		ProfileConfig profileConfig = mock(ProfileConfig.class);
+		when(profileConfig.basic()).thenReturn(true);
+		when(profileConfig.enhanced()).thenReturn(true);
+		when(profileConfig.full()).thenReturn(true);
+		when(element.getAnnotation(ProfileConfig.class)).thenReturn(profileConfig);
 
 		// provide elements annotated with Flatten annotation
 		Set<Element> set = new HashSet<Element>();
@@ -246,11 +246,11 @@ public class TraceeContextProviderMethodProcessorTest {
 		when(element.getEnclosingElement()).thenReturn(parentElement);
 
 		// prepare profile settings
-		ProfileSettings profileSettings = mock(ProfileSettings.class);
-		when(profileSettings.basic()).thenReturn(true);
-		when(profileSettings.enhanced()).thenReturn(true);
-		when(profileSettings.full()).thenReturn(true);
-		when(element.getAnnotation(ProfileSettings.class)).thenReturn(profileSettings);
+		ProfileConfig profileConfig = mock(ProfileConfig.class);
+		when(profileConfig.basic()).thenReturn(true);
+		when(profileConfig.enhanced()).thenReturn(true);
+		when(profileConfig.full()).thenReturn(true);
+		when(element.getAnnotation(ProfileConfig.class)).thenReturn(profileConfig);
 
 		// provide elements annotated with Flatten annotation
 		Set<Element> set = new HashSet<Element>();

--- a/contextprovider/annotationprocessor/src/test/java/io/tracee/contextlogger/contextprovider/api/TraceeContextProviderProcessorTest.java
+++ b/contextprovider/annotationprocessor/src/test/java/io/tracee/contextlogger/contextprovider/api/TraceeContextProviderProcessorTest.java
@@ -145,13 +145,13 @@ public class TraceeContextProviderProcessorTest {
 
 		TraceeContextProviderProcessor spy = Mockito.spy(unit);
 
-		ProfileSettings profileSettings = mock(ProfileSettings.class);
-		when(profileSettings.basic()).thenReturn(true);
-		when(profileSettings.enhanced()).thenReturn(true);
-		when(profileSettings.full()).thenReturn(true);
+		ProfileConfig profileConfig = mock(ProfileConfig.class);
+		when(profileConfig.basic()).thenReturn(true);
+		when(profileConfig.enhanced()).thenReturn(true);
+		when(profileConfig.full()).thenReturn(true);
 
 		TypeElement typeElement = mock(TypeElement.class);
-		when(typeElement.getAnnotation(ProfileSettings.class)).thenReturn(profileSettings);
+		when(typeElement.getAnnotation(ProfileConfig.class)).thenReturn(profileConfig);
 
 		Set<Element> set = new HashSet<Element>();
 		set.add(typeElement);
@@ -183,10 +183,10 @@ public class TraceeContextProviderProcessorTest {
 
 		TraceeContextProviderProcessor spy = Mockito.spy(unit);
 
-		ProfileSettings profileSettings = null;
+		ProfileConfig profileConfig = null;
 
 		TypeElement typeElement = mock(TypeElement.class);
-		when(typeElement.getAnnotation(ProfileSettings.class)).thenReturn(profileSettings);
+		when(typeElement.getAnnotation(ProfileConfig.class)).thenReturn(profileConfig);
 
 		Set<Element> set = new HashSet<Element>();
 		set.add(typeElement);
@@ -219,13 +219,13 @@ public class TraceeContextProviderProcessorTest {
 
 		TraceeContextProviderProcessor spy = Mockito.spy(unit);
 
-		ProfileSettings profileSettings = mock(ProfileSettings.class);
-		when(profileSettings.basic()).thenReturn(true);
-		when(profileSettings.enhanced()).thenReturn(true);
-		when(profileSettings.full()).thenReturn(true);
+		ProfileConfig profileConfig = mock(ProfileConfig.class);
+		when(profileConfig.basic()).thenReturn(true);
+		when(profileConfig.enhanced()).thenReturn(true);
+		when(profileConfig.full()).thenReturn(true);
 
 		TypeElement typeElement = mock(TypeElement.class);
-		when(typeElement.getAnnotation(ProfileSettings.class)).thenReturn(profileSettings);
+		when(typeElement.getAnnotation(ProfileConfig.class)).thenReturn(profileConfig);
 
 		Set<Element> set = new HashSet<Element>();
 		set.add(typeElement);
@@ -257,13 +257,13 @@ public class TraceeContextProviderProcessorTest {
 
 		TraceeContextProviderProcessor spy = Mockito.spy(unit);
 
-		ProfileSettings profileSettings = mock(ProfileSettings.class);
-		when(profileSettings.basic()).thenReturn(true);
-		when(profileSettings.enhanced()).thenReturn(true);
-		when(profileSettings.full()).thenReturn(true);
+		ProfileConfig profileConfig = mock(ProfileConfig.class);
+		when(profileConfig.basic()).thenReturn(true);
+		when(profileConfig.enhanced()).thenReturn(true);
+		when(profileConfig.full()).thenReturn(true);
 
 		TypeElement typeElement = mock(TypeElement.class);
-		when(typeElement.getAnnotation(ProfileSettings.class)).thenReturn(profileSettings);
+		when(typeElement.getAnnotation(ProfileConfig.class)).thenReturn(profileConfig);
 
 		Set<Element> set = new HashSet<Element>();
 		set.add(typeElement);
@@ -295,13 +295,13 @@ public class TraceeContextProviderProcessorTest {
 
 		TraceeContextProviderProcessor spy = Mockito.spy(unit);
 
-		ProfileSettings profileSettings = mock(ProfileSettings.class);
-		when(profileSettings.basic()).thenReturn(true);
-		when(profileSettings.enhanced()).thenReturn(true);
-		when(profileSettings.full()).thenReturn(true);
+		ProfileConfig profileConfig = mock(ProfileConfig.class);
+		when(profileConfig.basic()).thenReturn(true);
+		when(profileConfig.enhanced()).thenReturn(true);
+		when(profileConfig.full()).thenReturn(true);
 
 		TypeElement typeElement = mock(TypeElement.class);
-		when(typeElement.getAnnotation(ProfileSettings.class)).thenReturn(profileSettings);
+		when(typeElement.getAnnotation(ProfileConfig.class)).thenReturn(profileConfig);
 
 		Set<Element> set = new HashSet<Element>();
 		set.add(typeElement);

--- a/contextprovider/api/src/main/java/io/tracee/contextlogger/contextprovider/api/ImplicitContext.java
+++ b/contextprovider/api/src/main/java/io/tracee/contextlogger/contextprovider/api/ImplicitContext.java
@@ -1,10 +1,8 @@
 package io.tracee.contextlogger.contextprovider.api;
 
 /**
- * Defines all existing implicit contexts
+ * Enums can be used to add implicit context providers to string representation output.
  * Created by Tobias Gindler, holisticon AG on 14.03.14.
  */
-public enum ImplicitContext {
-	TRACEE,
-	COMMON;
+public interface ImplicitContext {
 }

--- a/contextprovider/api/src/main/java/io/tracee/contextlogger/contextprovider/api/ImplicitContextData.java
+++ b/contextprovider/api/src/main/java/io/tracee/contextlogger/contextprovider/api/ImplicitContextData.java
@@ -6,9 +6,12 @@ package io.tracee.contextlogger.contextprovider.api;
  */
 public interface ImplicitContextData {
 
-    /**
-     * Gets the implict context type.
-     */
-    ImplicitContext getImplicitContext();
+	/**
+	 * Used to map enum values against implicit context providers.
+	 * This allows adding of implicit context providers to string representation builder output just by adding the corresponding enum value.
+	 *
+	 * @return an enum value that implements the ImplicitContext interface
+	 */
+	ImplicitContext getImplicitContext();
 
 }

--- a/contextprovider/api/src/main/java/io/tracee/contextlogger/contextprovider/api/ProfileConfig.java
+++ b/contextprovider/api/src/main/java/io/tracee/contextlogger/contextprovider/api/ProfileConfig.java
@@ -6,8 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Used to annotate classes or methods annotated with
- *
+ * Configures if annotated class or method should be outputted in string representation builder output.
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD, ElementType.TYPE})

--- a/contextprovider/api/src/main/java/io/tracee/contextlogger/contextprovider/api/ProfileConfig.java
+++ b/contextprovider/api/src/main/java/io/tracee/contextlogger/contextprovider/api/ProfileConfig.java
@@ -11,7 +11,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD, ElementType.TYPE})
-public @interface ProfileSettings {
+public @interface ProfileConfig {
 
 	boolean basic() default false;
 

--- a/contextprovider/api/src/main/java/io/tracee/contextlogger/contextprovider/api/ProfileSettings.java
+++ b/contextprovider/api/src/main/java/io/tracee/contextlogger/contextprovider/api/ProfileSettings.java
@@ -5,6 +5,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * Used to annotate classes or methods annotated with
+ *
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(value = {ElementType.METHOD, ElementType.TYPE})
 public @interface ProfileSettings {

--- a/contextprovider/aspectj/src/main/java/io/tracee/contextlogger/contextprovider/aspectj/WatchdogAspect.java
+++ b/contextprovider/aspectj/src/main/java/io/tracee/contextlogger/contextprovider/aspectj/WatchdogAspect.java
@@ -1,5 +1,13 @@
 package io.tracee.contextlogger.contextprovider.aspectj;
 
+import io.tracee.contextlogger.MessagePrefixProvider;
+import io.tracee.contextlogger.TraceeContextLogger;
+import io.tracee.contextlogger.api.ErrorMessage;
+import io.tracee.contextlogger.api.internal.MessageLogLevel;
+import io.tracee.contextlogger.contextprovider.aspectj.contextprovider.WatchdogDataWrapper;
+import io.tracee.contextlogger.contextprovider.aspectj.util.WatchdogUtils;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
+import io.tracee.contextlogger.contextprovider.core.tracee.TraceeMessage;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
@@ -7,120 +15,108 @@ import org.aspectj.lang.annotation.Pointcut;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import io.tracee.contextlogger.MessagePrefixProvider;
-import io.tracee.contextlogger.TraceeContextLogger;
-import io.tracee.contextlogger.api.ErrorMessage;
-import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
-import io.tracee.contextlogger.api.internal.MessageLogLevel;
-import io.tracee.contextlogger.contextprovider.aspectj.contextprovider.WatchdogDataWrapper;
-import io.tracee.contextlogger.contextprovider.aspectj.util.WatchdogUtils;
-import io.tracee.contextlogger.contextprovider.core.tracee.TraceeMessage;
-
 /**
  * Watchdog Assert class.
  * This aspect logs method calls of Watchdog annotated classes and methods in case of an exception is thrown during the execution of the method.
- * <p/>
+ * <p>
  * Created by Tobias Gindler, holisticon AG on 16.02.14.
  */
 
 @Aspect
 public class WatchdogAspect {
 
-    private static final Logger logger = LoggerFactory.getLogger(WatchdogAspect.class);
+	private static final Logger logger = LoggerFactory.getLogger(WatchdogAspect.class);
 
-    private final boolean active;
+	private final boolean active;
 
-    public WatchdogAspect() {
-        this(Boolean.valueOf(System.getProperty(Constants.SYSTEM_PROPERTY_IS_ACTIVE, "true")));
-    }
+	public WatchdogAspect() {
+		this(Boolean.valueOf(System.getProperty(Constants.SYSTEM_PROPERTY_IS_ACTIVE, "true")));
+	}
 
-    WatchdogAspect(boolean active) {
-        this.active = active;
-    }
+	WatchdogAspect(boolean active) {
+		this.active = active;
+	}
 
-    @SuppressWarnings("unused")
-    @Pointcut("(execution(* *(..)) && @annotation(io.tracee.contextlogger.contextprovider.aspectj.Watchdog))")
-    void withinWatchdogAnnotatedMethods() {
-    }
+	@SuppressWarnings("unused")
+	@Pointcut("(execution(* *(..)) && @annotation(io.tracee.contextlogger.contextprovider.aspectj.Watchdog))")
+	void withinWatchdogAnnotatedMethods() {
+	}
 
-    @SuppressWarnings("unused")
-    @Pointcut("within(@io.tracee.contextlogger.contextprovider.aspectj.Watchdog *)")
-    void withinClassWithWatchdogAnnotation() {
+	@SuppressWarnings("unused")
+	@Pointcut("within(@io.tracee.contextlogger.contextprovider.aspectj.Watchdog *)")
+	void withinClassWithWatchdogAnnotation() {
 
-    }
+	}
 
-    @SuppressWarnings("unused")
-    @Pointcut("execution(public * *(..))")
-    void publicMethods() {
+	@SuppressWarnings("unused")
+	@Pointcut("execution(public * *(..))")
+	void publicMethods() {
 
-    }
+	}
 
-    @SuppressWarnings("unused")
-    @Around("withinWatchdogAnnotatedMethods() || (publicMethods() && withinClassWithWatchdogAnnotation()) ")
-    public Object guard(final ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+	@SuppressWarnings("unused")
+	@Around("withinWatchdogAnnotatedMethods() || (publicMethods() && withinClassWithWatchdogAnnotation()) ")
+	public Object guard(final ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
 
-        try {
-            return proceedingJoinPoint.proceed();
-        }
-        catch (final Throwable e) {
+		try {
+			return proceedingJoinPoint.proceed();
+		} catch (final Throwable e) {
 
-            // check if watchdog processing is flagged as active
-            if (active) {
+			// check if watchdog processing is flagged as active
+			if (active) {
 
-                // make sure that original exception will be passed through
-                try {
+				// make sure that original exception will be passed through
+				try {
 
-                    // get watchdog annotation
-                    Watchdog watchdog = WatchdogUtils.getWatchdogAnnotation(proceedingJoinPoint);
+					// get watchdog annotation
+					Watchdog watchdog = WatchdogUtils.getWatchdogAnnotation(proceedingJoinPoint);
 
-                    // check if watchdog aspect processing is deactivated by annotation
-                    if (WatchdogUtils.checkProcessWatchdog(watchdog, proceedingJoinPoint, e)) {
+					// check if watchdog aspect processing is deactivated by annotation
+					if (WatchdogUtils.checkProcessWatchdog(watchdog, proceedingJoinPoint, e)) {
 
-                        String annotatedId = watchdog.id().isEmpty() ? null : watchdog.id();
-                        sendErrorReportToConnectors(proceedingJoinPoint, annotatedId, e);
+						String annotatedId = watchdog.id().isEmpty() ? null : watchdog.id();
+						sendErrorReportToConnectors(proceedingJoinPoint, annotatedId, e);
 
-                    }
+					}
 
-                }
-                catch (Throwable error) {
-                    // will be ignored
-                    logger.error("error", error);
-                }
-            }
-            // rethrow exception
-            throw e;
-        }
+				} catch (Throwable error) {
+					// will be ignored
+					logger.error("error", error);
+				}
+			}
+			// rethrow exception
+			throw e;
+		}
 
-    }
+	}
 
-    /**
-     * Sends the error reports to all connectors.
-     *
-     * @param proceedingJoinPoint the aspectj calling context
-     * @param annotatedId the id defined in the watchdog annotation
-     */
-    void sendErrorReportToConnectors(ProceedingJoinPoint proceedingJoinPoint, String annotatedId, Throwable e) {
+	/**
+	 * Sends the error reports to all connectors.
+	 *
+	 * @param proceedingJoinPoint the aspectj calling context
+	 * @param annotatedId         the id defined in the watchdog annotation
+	 */
+	void sendErrorReportToConnectors(ProceedingJoinPoint proceedingJoinPoint, String annotatedId, Throwable e) {
 
-        // try to get error message annotation
-        ErrorMessage errorMessage = WatchdogUtils.getErrorMessageAnnotation(proceedingJoinPoint);
+		// try to get error message annotation
+		ErrorMessage errorMessage = WatchdogUtils.getErrorMessageAnnotation(proceedingJoinPoint);
 
-        if (errorMessage == null) {
-            TraceeContextLogger
-                    .create()
-                    .enforceOrder()
-                    .apply()
-                    .logWithPrefixedMessage(MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, Watchdog.class), ImplicitContext.COMMON,
-                            ImplicitContext.TRACEE, WatchdogDataWrapper.wrap(annotatedId, proceedingJoinPoint), e);
-        }
-        else {
-            TraceeContextLogger
-                    .create()
-                    .enforceOrder()
-                    .apply()
-                    .logWithPrefixedMessage(MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, Watchdog.class),
-                            TraceeMessage.wrap(errorMessage.value()), ImplicitContext.COMMON, ImplicitContext.TRACEE,
-                            WatchdogDataWrapper.wrap(annotatedId, proceedingJoinPoint), e);
-        }
-    }
+		if (errorMessage == null) {
+			TraceeContextLogger
+					.create()
+					.enforceOrder()
+					.apply()
+					.logWithPrefixedMessage(MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, Watchdog.class), CoreImplicitContextProviders.COMMON,
+							CoreImplicitContextProviders.TRACEE, WatchdogDataWrapper.wrap(annotatedId, proceedingJoinPoint), e);
+		} else {
+			TraceeContextLogger
+					.create()
+					.enforceOrder()
+					.apply()
+					.logWithPrefixedMessage(MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, Watchdog.class),
+							TraceeMessage.wrap(errorMessage.value()), CoreImplicitContextProviders.COMMON, CoreImplicitContextProviders.TRACEE,
+							WatchdogDataWrapper.wrap(annotatedId, proceedingJoinPoint), e);
+		}
+	}
 
 }

--- a/contextprovider/aspectj/src/main/java/io/tracee/contextlogger/contextprovider/aspectj/contextprovider/AspectjProceedingJoinPointContextProvider.java
+++ b/contextprovider/aspectj/src/main/java/io/tracee/contextlogger/contextprovider/aspectj/contextprovider/AspectjProceedingJoinPointContextProvider.java
@@ -1,6 +1,6 @@
 package io.tracee.contextlogger.contextprovider.aspectj.contextprovider;
 
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
@@ -14,7 +14,7 @@ import java.util.List;
  * Created by Tobias Gindler, holisticon AG on 20.03.14.
  */
 @TraceeContextProvider(displayName = "proceedingJoinPoint")
-@ProfileSettings(basic = true, enhanced = true, full = true)
+@ProfileConfig(basic = true, enhanced = true, full = true)
 public class AspectjProceedingJoinPointContextProvider implements WrappedContextData<ProceedingJoinPoint> {
 
 	private ProceedingJoinPoint proceedingJoinPoint;
@@ -48,7 +48,7 @@ public class AspectjProceedingJoinPointContextProvider implements WrappedContext
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "class", order = 20)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public final String getClazz() {
 		if (proceedingJoinPoint != null && proceedingJoinPoint.getSignature() != null) {
 			return proceedingJoinPoint.getSignature().getDeclaringTypeName();
@@ -58,7 +58,7 @@ public class AspectjProceedingJoinPointContextProvider implements WrappedContext
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "method", order = 30)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public final String getMethod() {
 		if (proceedingJoinPoint != null && proceedingJoinPoint.getSignature() != null) {
 			return proceedingJoinPoint.getSignature().getName();
@@ -68,7 +68,7 @@ public class AspectjProceedingJoinPointContextProvider implements WrappedContext
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "parameters", order = 40)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public final List<Object> getParameters() {
 
 		if (proceedingJoinPoint != null && proceedingJoinPoint.getArgs() != null) {
@@ -80,7 +80,7 @@ public class AspectjProceedingJoinPointContextProvider implements WrappedContext
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "serialized-target-instance", order = 50)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public final Object getSerializedTargetInstance() {
 		if (proceedingJoinPoint != null) {
 			// output invoked instance

--- a/contextprovider/aspectj/src/main/java/io/tracee/contextlogger/contextprovider/aspectj/contextprovider/WatchdogContextProvider.java
+++ b/contextprovider/aspectj/src/main/java/io/tracee/contextlogger/contextprovider/aspectj/contextprovider/WatchdogContextProvider.java
@@ -3,7 +3,7 @@ package io.tracee.contextlogger.contextprovider.aspectj.contextprovider;
 import io.tracee.contextlogger.contextprovider.api.Order;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
 
 /**
@@ -12,7 +12,7 @@ import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
  */
 @SuppressWarnings("unused")
 @TraceeContextProvider(displayName = "watchdog", order = Order.WATCHDOG)
-@ProfileSettings(basic = true, enhanced = true, full = true)
+@ProfileConfig(basic = true, enhanced = true, full = true)
 public final class WatchdogContextProvider implements WrappedContextData<WatchdogDataWrapper> {
 
 	private WatchdogDataWrapper watchdogDataWrapper;
@@ -42,7 +42,7 @@ public final class WatchdogContextProvider implements WrappedContextData<Watchdo
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "id", order = 10)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public String getId() {
 		if (watchdogDataWrapper != null) {
 			return watchdogDataWrapper.getAnnotatedId();
@@ -52,7 +52,7 @@ public final class WatchdogContextProvider implements WrappedContextData<Watchdo
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "aspectj.proceedingJoinPoint", order = 20)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public AspectjProceedingJoinPointContextProvider getProceedingJoinPoint() {
 		if (watchdogDataWrapper != null && watchdogDataWrapper.getProceedingJoinPoint() != null) {
 			return AspectjProceedingJoinPointContextProvider.wrap(watchdogDataWrapper.getProceedingJoinPoint());

--- a/contextprovider/core/src/main/java/io/tracee/contextlogger/contextprovider/core/CoreImplicitContextProviders.java
+++ b/contextprovider/core/src/main/java/io/tracee/contextlogger/contextprovider/core/CoreImplicitContextProviders.java
@@ -1,0 +1,22 @@
+package io.tracee.contextlogger.contextprovider.core;
+
+import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
+import io.tracee.contextlogger.contextprovider.core.tracee.CommonDataContextProvider;
+import io.tracee.contextlogger.contextprovider.core.tracee.TraceeMdcContextProvider;
+
+/**
+ * Enum that can be used to provide implicit core context providers.
+ */
+public enum CoreImplicitContextProviders implements ImplicitContext {
+
+	TRACEE(TraceeMdcContextProvider.class),
+	COMMON(CommonDataContextProvider.class);
+
+	private final Class implicitContextProviderClass;
+
+	private CoreImplicitContextProviders(final Class implicitContextProviderClass) {
+		this.implicitContextProviderClass = implicitContextProviderClass;
+
+	}
+
+}

--- a/contextprovider/core/src/main/java/io/tracee/contextlogger/contextprovider/core/java/JavaThrowableContextProvider.java
+++ b/contextprovider/core/src/main/java/io/tracee/contextlogger/contextprovider/core/java/JavaThrowableContextProvider.java
@@ -1,7 +1,7 @@
 package io.tracee.contextlogger.contextprovider.core.java;
 
 import io.tracee.contextlogger.contextprovider.api.Order;
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
@@ -15,7 +15,7 @@ import java.io.StringWriter;
  */
 @SuppressWarnings("unused")
 @TraceeContextProvider(displayName = "throwable", order = Order.EXCEPTION)
-@ProfileSettings(basic = true, enhanced = true, full = true)
+@ProfileConfig(basic = true, enhanced = true, full = true)
 public final class JavaThrowableContextProvider implements WrappedContextData<Throwable> {
 
 	private Throwable throwable;
@@ -46,14 +46,14 @@ public final class JavaThrowableContextProvider implements WrappedContextData<Th
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "message", order = 10)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public String getMessage() {
 		return throwable != null ? throwable.getMessage() : null;
 	}
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "stacktrace", order = 20)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public String getStacktrace() {
 		if (this.throwable != null) {
 			StringWriter sw = new StringWriter();

--- a/contextprovider/core/src/main/java/io/tracee/contextlogger/contextprovider/core/tracee/CommonDataContextProvider.java
+++ b/contextprovider/core/src/main/java/io/tracee/contextlogger/contextprovider/core/tracee/CommonDataContextProvider.java
@@ -3,7 +3,7 @@ package io.tracee.contextlogger.contextprovider.core.tracee;
 import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
 import io.tracee.contextlogger.contextprovider.api.ImplicitContextData;
 import io.tracee.contextlogger.contextprovider.api.Order;
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 
@@ -17,7 +17,7 @@ import java.util.Date;
  * Created by Tobias Gindler, holisticon AG on 14.03.14.
  */
 @TraceeContextProvider(displayName = "common", order = Order.COMMON)
-@ProfileSettings(basic = true, enhanced = true, full = true)
+@ProfileConfig(basic = true, enhanced = true, full = true)
 public class CommonDataContextProvider implements ImplicitContextData {
 
 	public static final String SYSTEM_PROPERTY_PREFIX = "io.tracee.contextlogger.";
@@ -31,7 +31,7 @@ public class CommonDataContextProvider implements ImplicitContextData {
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "timestamp", order = 10)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 
 	public final Date getTimestamp() {
 		return Calendar.getInstance().getTime();
@@ -39,14 +39,14 @@ public class CommonDataContextProvider implements ImplicitContextData {
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "stage", order = 20)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public final String getStage() {
 		return getSystemProperty(SYSTEM_PROPERTY_NAME_STAGE);
 	}
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "system-name", order = 30)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 
 	public final String getSystemName() {
 
@@ -66,14 +66,14 @@ public class CommonDataContextProvider implements ImplicitContextData {
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "thread-name", order = 40)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public final String getThreadName() {
 		return Thread.currentThread().getName();
 	}
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "thread-id", order = 50)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public final Long getThreadId() {
 		return Thread.currentThread().getId();
 	}

--- a/contextprovider/core/src/main/java/io/tracee/contextlogger/contextprovider/core/tracee/CommonDataContextProvider.java
+++ b/contextprovider/core/src/main/java/io/tracee/contextlogger/contextprovider/core/tracee/CommonDataContextProvider.java
@@ -6,6 +6,7 @@ import io.tracee.contextlogger.contextprovider.api.Order;
 import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
 
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -26,7 +27,7 @@ public class CommonDataContextProvider implements ImplicitContextData {
 
 	@Override
 	public final ImplicitContext getImplicitContext() {
-		return ImplicitContext.COMMON;
+		return CoreImplicitContextProviders.COMMON;
 	}
 
 	@SuppressWarnings("unused")

--- a/contextprovider/core/src/main/java/io/tracee/contextlogger/contextprovider/core/tracee/TraceeMdcContextProvider.java
+++ b/contextprovider/core/src/main/java/io/tracee/contextlogger/contextprovider/core/tracee/TraceeMdcContextProvider.java
@@ -7,6 +7,7 @@ import io.tracee.contextlogger.contextprovider.api.Order;
 import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
 import io.tracee.contextlogger.contextprovider.core.utility.NameValuePair;
 import org.slf4j.MDC;
 
@@ -29,7 +30,7 @@ public final class TraceeMdcContextProvider implements ImplicitContextData {
 
 	@Override
 	public ImplicitContext getImplicitContext() {
-		return ImplicitContext.TRACEE;
+		return CoreImplicitContextProviders.TRACEE;
 	}
 
 	@SuppressWarnings("unused")

--- a/contextprovider/core/src/main/java/io/tracee/contextlogger/contextprovider/core/tracee/TraceeMdcContextProvider.java
+++ b/contextprovider/core/src/main/java/io/tracee/contextlogger/contextprovider/core/tracee/TraceeMdcContextProvider.java
@@ -4,7 +4,7 @@ import io.tracee.contextlogger.contextprovider.api.Flatten;
 import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
 import io.tracee.contextlogger.contextprovider.api.ImplicitContextData;
 import io.tracee.contextlogger.contextprovider.api.Order;
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 import io.tracee.contextlogger.contextprovider.core.utility.NameValuePair;
@@ -20,7 +20,7 @@ import java.util.Map;
  */
 @SuppressWarnings("unused")
 @TraceeContextProvider(displayName = "tracee", order = Order.TRACEE)
-@ProfileSettings(basic = true, enhanced = true, full = true)
+@ProfileConfig(basic = true, enhanced = true, full = true)
 public final class TraceeMdcContextProvider implements ImplicitContextData {
 
 	public TraceeMdcContextProvider() {
@@ -35,7 +35,7 @@ public final class TraceeMdcContextProvider implements ImplicitContextData {
 	@SuppressWarnings("unused")
 	@Flatten
 	@TraceeContextProviderMethod(displayName = "DYNAMIC", order = 10)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public List<NameValuePair<String>> getNameValuePairs() {
 
 		final List<NameValuePair<String>> list = new ArrayList<NameValuePair<String>>();

--- a/contextprovider/core/src/main/java/io/tracee/contextlogger/contextprovider/core/tracee/TraceeMessageContextProvider.java
+++ b/contextprovider/core/src/main/java/io/tracee/contextlogger/contextprovider/core/tracee/TraceeMessageContextProvider.java
@@ -3,7 +3,7 @@ package io.tracee.contextlogger.contextprovider.core.tracee;
 import io.tracee.contextlogger.contextprovider.api.Order;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
 
 /**
@@ -12,7 +12,7 @@ import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
  */
 @SuppressWarnings("unused")
 @TraceeContextProvider(displayName = "message", order = Order.MESSAGE)
-@ProfileSettings(basic = true, enhanced = true, full = true)
+@ProfileConfig(basic = true, enhanced = true, full = true)
 
 public class TraceeMessageContextProvider implements WrappedContextData<TraceeMessage> {
 
@@ -51,7 +51,7 @@ public class TraceeMessageContextProvider implements WrappedContextData<TraceeMe
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "value", order = 10, enabledPerDefault = true)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public String getValue() {
 		if (message != null && message.getMessage() != null) {
 			return message.getMessage().toString();

--- a/contextprovider/core/src/test/java/io/tracee/contextlogger/contextprovider/core/tracee/CommonDataContextProviderTest.java
+++ b/contextprovider/core/src/test/java/io/tracee/contextlogger/contextprovider/core/tracee/CommonDataContextProviderTest.java
@@ -1,6 +1,7 @@
 package io.tracee.contextlogger.contextprovider.core.tracee;
 
 import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -18,7 +19,7 @@ import static org.hamcrest.Matchers.nullValue;
  * Test class for {@link CommonDataContextProvider}.
  * Created by Tobias Gindler, holisticon AG on 31.03.14.
  */
-public class CommonDataProviderTest {
+public class CommonDataContextProviderTest {
 
 	public static final String STAGE = "STAGE";
 	public static final String SYSTEM = "SYSTEM";
@@ -38,7 +39,7 @@ public class CommonDataProviderTest {
 		ImplicitContext implicitContext = commonDataContextProvider.getImplicitContext();
 
 		assertThat(implicitContext, notNullValue());
-		assertThat(implicitContext, equalTo(ImplicitContext.COMMON));
+		assertThat(implicitContext, equalTo((ImplicitContext) CoreImplicitContextProviders.COMMON));
 	}
 
 

--- a/contextprovider/javaee/src/main/java/io/tracee/contextlogger/contextprovider/javaee/TraceeErrorContextLoggingInterceptor.java
+++ b/contextprovider/javaee/src/main/java/io/tracee/contextlogger/contextprovider/javaee/TraceeErrorContextLoggingInterceptor.java
@@ -1,14 +1,14 @@
 package io.tracee.contextlogger.contextprovider.javaee;
 
-import javax.interceptor.AroundInvoke;
-import javax.interceptor.InvocationContext;
-
 import io.tracee.contextlogger.MessagePrefixProvider;
 import io.tracee.contextlogger.TraceeContextLogger;
 import io.tracee.contextlogger.api.ErrorMessage;
-import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
 import io.tracee.contextlogger.api.internal.MessageLogLevel;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
 import io.tracee.contextlogger.contextprovider.core.tracee.TraceeMessage;
+
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.InvocationContext;
 
 /**
  * Message listener to detect exceptions that happened during javaee message processing.
@@ -17,40 +17,38 @@ import io.tracee.contextlogger.contextprovider.core.tracee.TraceeMessage;
  */
 public class TraceeErrorContextLoggingInterceptor {
 
-    @SuppressWarnings("unused")
-    public TraceeErrorContextLoggingInterceptor() {
-    }
+	@SuppressWarnings("unused")
+	public TraceeErrorContextLoggingInterceptor() {
+	}
 
-    @AroundInvoke
-    public Object intercept(final InvocationContext ctx) throws Exception {
-        try {
-            return ctx.proceed();
-        }
-        catch (Exception e) {
+	@AroundInvoke
+	public Object intercept(final InvocationContext ctx) throws Exception {
+		try {
+			return ctx.proceed();
+		} catch (Exception e) {
 
-            // try to get error message annotation
-            ErrorMessage errorMessage = ctx.getMethod().getAnnotation(ErrorMessage.class);
+			// try to get error message annotation
+			ErrorMessage errorMessage = ctx.getMethod().getAnnotation(ErrorMessage.class);
 
-            // now log context informations
-            if (errorMessage == null) {
-                TraceeContextLogger
-                        .create()
-                        .enforceOrder()
-                        .apply()
-                        .logWithPrefixedMessage(
-                                MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, TraceeErrorContextLoggingInterceptor.class),
-                                ImplicitContext.COMMON, ImplicitContext.TRACEE, ctx, e);
-            }
-            else {
-                TraceeContextLogger
-                        .create()
-                        .enforceOrder()
-                        .apply()
-                        .logWithPrefixedMessage(
-                                MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, TraceeErrorContextLoggingInterceptor.class),
-                                TraceeMessage.wrap(errorMessage.value()), ImplicitContext.COMMON, ImplicitContext.TRACEE, ctx, e);
-            }
-            throw e;
-        }
-    }
+			// now log context informations
+			if (errorMessage == null) {
+				TraceeContextLogger
+						.create()
+						.enforceOrder()
+						.apply()
+						.logWithPrefixedMessage(
+								MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, TraceeErrorContextLoggingInterceptor.class),
+								CoreImplicitContextProviders.COMMON, CoreImplicitContextProviders.TRACEE, ctx, e);
+			} else {
+				TraceeContextLogger
+						.create()
+						.enforceOrder()
+						.apply()
+						.logWithPrefixedMessage(
+								MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, TraceeErrorContextLoggingInterceptor.class),
+								TraceeMessage.wrap(errorMessage.value()), CoreImplicitContextProviders.COMMON, CoreImplicitContextProviders.TRACEE, ctx, e);
+			}
+			throw e;
+		}
+	}
 }

--- a/contextprovider/javaee/src/main/java/io/tracee/contextlogger/contextprovider/javaee/TraceeJmsErrorMessageListener.java
+++ b/contextprovider/javaee/src/main/java/io/tracee/contextlogger/contextprovider/javaee/TraceeJmsErrorMessageListener.java
@@ -1,13 +1,12 @@
 package io.tracee.contextlogger.contextprovider.javaee;
 
-import java.lang.reflect.Method;
+import io.tracee.contextlogger.TraceeContextLogger;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
 
 import javax.interceptor.AroundInvoke;
 import javax.interceptor.InvocationContext;
 import javax.jms.Message;
-
-import io.tracee.contextlogger.TraceeContextLogger;
-import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
+import java.lang.reflect.Method;
 
 /**
  * Message listener to detect exceptions that happened during javaee message processing.
@@ -16,32 +15,31 @@ import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
  */
 public class TraceeJmsErrorMessageListener {
 
-    static final String JSON_PREFIXED_MESSAGE = "TRACEE JMS ERROR CONTEXT LOGGING LISTENER  : ";
+	static final String JSON_PREFIXED_MESSAGE = "TRACEE JMS ERROR CONTEXT LOGGING LISTENER  : ";
 
-    @SuppressWarnings("unused")
-    public TraceeJmsErrorMessageListener() {
+	@SuppressWarnings("unused")
+	public TraceeJmsErrorMessageListener() {
 
-    }
+	}
 
-    @AroundInvoke
-    public Object intercept(InvocationContext ctx) throws Exception {
-        try {
-            return ctx.proceed();
-        }
-        catch (Exception e) {
-            final boolean isMdbInvocation = isMessageListenerOnMessageMethod(ctx.getMethod());
+	@AroundInvoke
+	public Object intercept(InvocationContext ctx) throws Exception {
+		try {
+			return ctx.proceed();
+		} catch (Exception e) {
+			final boolean isMdbInvocation = isMessageListenerOnMessageMethod(ctx.getMethod());
 
-            if (isMdbInvocation) {
-                TraceeContextLogger.create().enforceOrder().apply()
-                        .logWithPrefixedMessage(JSON_PREFIXED_MESSAGE, ImplicitContext.COMMON, ImplicitContext.TRACEE, ctx, e);
-            }
+			if (isMdbInvocation) {
+				TraceeContextLogger.create().enforceOrder().apply()
+						.logWithPrefixedMessage(JSON_PREFIXED_MESSAGE, CoreImplicitContextProviders.COMMON, CoreImplicitContextProviders.TRACEE, ctx, e);
+			}
 
-            throw e;
-        }
-    }
+			throw e;
+		}
+	}
 
-    boolean isMessageListenerOnMessageMethod(Method method) {
-        return "onMessage".equals(method.getName()) && method.getParameterTypes().length == 1 && method.getParameterTypes()[0] == Message.class;
-    }
+	boolean isMessageListenerOnMessageMethod(Method method) {
+		return "onMessage".equals(method.getName()) && method.getParameterTypes().length == 1 && method.getParameterTypes()[0] == Message.class;
+	}
 
 }

--- a/contextprovider/javaee/src/main/java/io/tracee/contextlogger/contextprovider/javaee/contextprovider/InvocationContextContextProvider.java
+++ b/contextprovider/javaee/src/main/java/io/tracee/contextlogger/contextprovider/javaee/contextprovider/InvocationContextContextProvider.java
@@ -1,7 +1,7 @@
 package io.tracee.contextlogger.contextprovider.javaee.contextprovider;
 
 import io.tracee.contextlogger.contextprovider.api.Order;
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
@@ -17,7 +17,7 @@ import java.util.Map;
  * Created by Tobias Gindler, holisticon AG on 20.03.14.
  */
 @TraceeContextProvider(displayName = "invocationContext", order = Order.EJB)
-@ProfileSettings(basic = true, enhanced = true, full = true)
+@ProfileConfig(basic = true, enhanced = true, full = true)
 public class InvocationContextContextProvider implements WrappedContextData<InvocationContext> {
 
 	private InvocationContext invocationContext;
@@ -45,20 +45,20 @@ public class InvocationContextContextProvider implements WrappedContextData<Invo
 	}
 
 	@TraceeContextProviderMethod(displayName = "typeName", order = 0)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public final String getTypeName() {
 		return this.invocationContext != null && this.invocationContext.getTarget() != null && this.invocationContext.getTarget().getClass() != null
 				? this.invocationContext.getTarget().getClass().getCanonicalName() : null;
 	}
 
 	@TraceeContextProviderMethod(displayName = "methodName", order = 10)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public final String getMethodName() {
 		return this.invocationContext != null && this.invocationContext.getMethod() != null ? this.invocationContext.getMethod().getName() : null;
 	}
 
 	@TraceeContextProviderMethod(displayName = "parameters", order = 20)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public final List<String> getParameters() {
 
 		List<String> result = new ArrayList<String>();
@@ -75,7 +75,7 @@ public class InvocationContextContextProvider implements WrappedContextData<Invo
 	}
 
 	@TraceeContextProviderMethod(displayName = "target-instance", order = 30)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public final Object getTargetInstance() {
 		String result = null;
 		if (this.invocationContext != null) {
@@ -87,7 +87,7 @@ public class InvocationContextContextProvider implements WrappedContextData<Invo
 	}
 
 	@TraceeContextProviderMethod(displayName = "invocationContextData", order = 40)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public final List<NameValuePair<Object>> getInvocationContextData() {
 
 		List<NameValuePair<Object>> result = new ArrayList<NameValuePair<Object>>();

--- a/contextprovider/javaee/src/test/java/io/tracee/contextlogger/contextprovider/javaee/TraceeErrorContextLoggingInterceptorTest.java
+++ b/contextprovider/javaee/src/test/java/io/tracee/contextlogger/contextprovider/javaee/TraceeErrorContextLoggingInterceptorTest.java
@@ -1,14 +1,13 @@
 package io.tracee.contextlogger.contextprovider.javaee;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-
-import javax.interceptor.InvocationContext;
-
+import io.tracee.contextlogger.MessagePrefixProvider;
+import io.tracee.contextlogger.TraceeContextLogger;
+import io.tracee.contextlogger.api.ConfigBuilder;
+import io.tracee.contextlogger.api.ContextLogger;
+import io.tracee.contextlogger.api.ErrorMessage;
+import io.tracee.contextlogger.api.internal.MessageLogLevel;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
+import io.tracee.contextlogger.contextprovider.core.tracee.TraceeMessage;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,103 +15,106 @@ import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import io.tracee.contextlogger.MessagePrefixProvider;
-import io.tracee.contextlogger.TraceeContextLogger;
-import io.tracee.contextlogger.api.ConfigBuilder;
-import io.tracee.contextlogger.api.ContextLogger;
-import io.tracee.contextlogger.api.ErrorMessage;
-import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
-import io.tracee.contextlogger.api.internal.MessageLogLevel;
-import io.tracee.contextlogger.contextprovider.core.tracee.TraceeMessage;
+import javax.interceptor.InvocationContext;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 /**
  * Test class for {@link TraceeErrorContextLoggingInterceptor}.
  * Created by Tobias Gindler on 19.06.14.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ TraceeContextLogger.class, TraceeMessage.class, MessagePrefixProvider.class })
+@PrepareForTest({TraceeContextLogger.class, TraceeMessage.class, MessagePrefixProvider.class})
 public class TraceeErrorContextLoggingInterceptorTest {
 
-    private final static String LOG_MESSAGE_PREFIX = "XX";
+	private final static String LOG_MESSAGE_PREFIX = "XX";
 
-    public static final String ERROR_MESSAGE = "ABC";
+	public static final String ERROR_MESSAGE = "ABC";
 
-    private final TraceeErrorContextLoggingInterceptor unit = mock(TraceeErrorContextLoggingInterceptor.class);
+	private final TraceeErrorContextLoggingInterceptor unit = mock(TraceeErrorContextLoggingInterceptor.class);
 
-    private final ContextLogger contextLogger = mock(ContextLogger.class);
-    private final ConfigBuilder<ContextLogger> configBuilder = mock(ConfigBuilder.class);
+	private final ContextLogger contextLogger = mock(ContextLogger.class);
+	private final ConfigBuilder<ContextLogger> configBuilder = mock(ConfigBuilder.class);
 
-    private final TraceeMessage traceeMessage = new TraceeMessage("ABC");
+	private final TraceeMessage traceeMessage = new TraceeMessage("ABC");
 
-    @Before
-    public void setupMocks() throws Exception {
+	@Before
+	public void setupMocks() throws Exception {
 
-        // Let's return true for every Message. The intercept-method must call teh real method. otherwise
-        // we would test the mocking framework!
-        // java.lang.reflect.Method is not suitable for mocks. Also Powermock is unable to create a mock for it!
-        when(unit.intercept(Mockito.any(InvocationContext.class))).thenCallRealMethod();
-        mockStatic(TraceeContextLogger.class);
-        when(TraceeContextLogger.create()).thenReturn(configBuilder);
-        when(configBuilder.enforceOrder()).thenReturn(configBuilder);
-        when(configBuilder.apply()).thenReturn(contextLogger);
-        mockStatic(TraceeMessage.class);
-        when(TraceeMessage.wrap(ERROR_MESSAGE)).thenReturn(traceeMessage);
+		// Let's return true for every Message. The intercept-method must call teh real method. otherwise
+		// we would test the mocking framework!
+		// java.lang.reflect.Method is not suitable for mocks. Also Powermock is unable to create a mock for it!
+		when(unit.intercept(Mockito.any(InvocationContext.class))).thenCallRealMethod();
+		mockStatic(TraceeContextLogger.class);
+		when(TraceeContextLogger.create()).thenReturn(configBuilder);
+		when(configBuilder.enforceOrder()).thenReturn(configBuilder);
+		when(configBuilder.apply()).thenReturn(contextLogger);
+		mockStatic(TraceeMessage.class);
+		when(TraceeMessage.wrap(ERROR_MESSAGE)).thenReturn(traceeMessage);
 
-        // mock log message prefix creation
-        mockStatic(MessagePrefixProvider.class);
-        when(MessagePrefixProvider.provideLogMessagePrefix(Mockito.any(MessageLogLevel.class), Mockito.any(String.class))).thenReturn(LOG_MESSAGE_PREFIX);
-        when(MessagePrefixProvider.provideLogMessagePrefix(Mockito.any(MessageLogLevel.class), Mockito.any(Class.class))).thenReturn(LOG_MESSAGE_PREFIX);
-    }
+		// mock log message prefix creation
+		mockStatic(MessagePrefixProvider.class);
+		when(MessagePrefixProvider.provideLogMessagePrefix(Mockito.any(MessageLogLevel.class), Mockito.any(String.class))).thenReturn(LOG_MESSAGE_PREFIX);
+		when(MessagePrefixProvider.provideLogMessagePrefix(Mockito.any(MessageLogLevel.class), Mockito.any(Class.class))).thenReturn(LOG_MESSAGE_PREFIX);
+	}
 
-    @Test
-    public void shouldBeInitializable() {
-        assertThat(new TraceeErrorContextLoggingInterceptor(), is(not(nullValue())));
-    }
+	@Test
+	public void shouldBeInitializable() {
+		assertThat(new TraceeErrorContextLoggingInterceptor(), is(not(nullValue())));
+	}
 
-    @Test
-    public void noInteractionWhenNoExceptionOccurs() throws Exception {
-        final InvocationContext invocationContext = mock(InvocationContext.class);
+	@Test
+	public void noInteractionWhenNoExceptionOccurs() throws Exception {
+		final InvocationContext invocationContext = mock(InvocationContext.class);
 
-        unit.intercept(invocationContext);
-        verify(invocationContext).proceed();
-        verify(contextLogger, never()).logWithPrefixedMessage(anyString(), any(), any(), any(), any());
-    }
+		unit.intercept(invocationContext);
+		verify(invocationContext).proceed();
+		verify(contextLogger, never()).logWithPrefixedMessage(anyString(), any(), any(), any(), any());
+	}
 
-    @Test(expected = RuntimeException.class)
-    public void logJsonWithPrefixedMessageIfAnExceptionOccurs() throws Exception {
-        final InvocationContext invocationContext = mock(InvocationContext.class);
-        final RuntimeException exception = new RuntimeException();
-        when(invocationContext.proceed()).thenThrow(exception);
-        when(invocationContext.getMethod()).thenReturn(
-                TraceeErrorContextLoggingInterceptorTest.class.getMethod("logJsonWithPrefixedMessageIfAnExceptionOccurs", null));
+	@Test(expected = RuntimeException.class)
+	public void logJsonWithPrefixedMessageIfAnExceptionOccurs() throws Exception {
+		final InvocationContext invocationContext = mock(InvocationContext.class);
+		final RuntimeException exception = new RuntimeException();
+		when(invocationContext.proceed()).thenThrow(exception);
+		when(invocationContext.getMethod()).thenReturn(
+				TraceeErrorContextLoggingInterceptorTest.class.getMethod("logJsonWithPrefixedMessageIfAnExceptionOccurs", null));
 
-        try {
-            unit.intercept(invocationContext);
-        }
-        catch (Exception e) {
-            verify(invocationContext).proceed();
-            verify(contextLogger).logWithPrefixedMessage(LOG_MESSAGE_PREFIX, ImplicitContext.COMMON, ImplicitContext.TRACEE, invocationContext, exception);
-            throw e;
-        }
-    }
+		try {
+			unit.intercept(invocationContext);
+		} catch (Exception e) {
+			verify(invocationContext).proceed();
+			verify(contextLogger).logWithPrefixedMessage(LOG_MESSAGE_PREFIX, CoreImplicitContextProviders.COMMON, CoreImplicitContextProviders.TRACEE, invocationContext, exception);
+			throw e;
+		}
+	}
 
-    @ErrorMessage(ERROR_MESSAGE)
-    @Test(expected = RuntimeException.class)
-    public void logJsonWithAnnotatedMessageAndPrefixedMessageIfAnExceptionOccurs() throws Exception {
-        final InvocationContext invocationContext = mock(InvocationContext.class);
-        final RuntimeException exception = new RuntimeException();
-        when(invocationContext.proceed()).thenThrow(exception);
-        when(invocationContext.getMethod()).thenReturn(
-                TraceeErrorContextLoggingInterceptorTest.class.getMethod("logJsonWithAnnotatedMessageAndPrefixedMessageIfAnExceptionOccurs", null));
+	@ErrorMessage(ERROR_MESSAGE)
+	@Test(expected = RuntimeException.class)
+	public void logJsonWithAnnotatedMessageAndPrefixedMessageIfAnExceptionOccurs() throws Exception {
+		final InvocationContext invocationContext = mock(InvocationContext.class);
+		final RuntimeException exception = new RuntimeException();
+		when(invocationContext.proceed()).thenThrow(exception);
+		when(invocationContext.getMethod()).thenReturn(
+				TraceeErrorContextLoggingInterceptorTest.class.getMethod("logJsonWithAnnotatedMessageAndPrefixedMessageIfAnExceptionOccurs", null));
 
-        try {
-            unit.intercept(invocationContext);
-        }
-        catch (Exception e) {
-            verify(invocationContext).proceed();
-            verify(contextLogger).logWithPrefixedMessage(LOG_MESSAGE_PREFIX, traceeMessage, ImplicitContext.COMMON, ImplicitContext.TRACEE,
-                    invocationContext, exception);
-            throw e;
-        }
-    }
+		try {
+			unit.intercept(invocationContext);
+		} catch (Exception e) {
+			verify(invocationContext).proceed();
+			verify(contextLogger).logWithPrefixedMessage(LOG_MESSAGE_PREFIX, traceeMessage, CoreImplicitContextProviders.COMMON, CoreImplicitContextProviders.TRACEE,
+					invocationContext, exception);
+			throw e;
+		}
+	}
 }

--- a/contextprovider/javaee/src/test/java/io/tracee/contextlogger/contextprovider/javaee/TraceeJmsErrorMessageListenerTest.java
+++ b/contextprovider/javaee/src/test/java/io/tracee/contextlogger/contextprovider/javaee/TraceeJmsErrorMessageListenerTest.java
@@ -1,16 +1,9 @@
 package io.tracee.contextlogger.contextprovider.javaee;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.*;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-
-import java.lang.reflect.Method;
-
-import javax.interceptor.InvocationContext;
-
+import io.tracee.contextlogger.TraceeContextLogger;
+import io.tracee.contextlogger.api.ConfigBuilder;
+import io.tracee.contextlogger.api.ContextLogger;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,10 +11,20 @@ import org.mockito.Mockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import io.tracee.contextlogger.TraceeContextLogger;
-import io.tracee.contextlogger.api.ConfigBuilder;
-import io.tracee.contextlogger.api.ContextLogger;
-import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
+import javax.interceptor.InvocationContext;
+import java.lang.reflect.Method;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
 @RunWith(PowerMockRunner.class)
 @PrepareForTest(TraceeContextLogger.class)
@@ -73,8 +76,8 @@ public class TraceeJmsErrorMessageListenerTest {
         }
         catch (Exception e) {
             verify(invocationContext).proceed();
-            verify(contextLogger).logWithPrefixedMessage(TraceeJmsErrorMessageListener.JSON_PREFIXED_MESSAGE, ImplicitContext.COMMON,
-                    ImplicitContext.TRACEE, invocationContext, exception);
+            verify(contextLogger).logWithPrefixedMessage(TraceeJmsErrorMessageListener.JSON_PREFIXED_MESSAGE, CoreImplicitContextProviders.COMMON,
+					CoreImplicitContextProviders.TRACEE, invocationContext, exception);
             throw e;
         }
     }

--- a/contextprovider/jaxws/src/main/java/io/tracee/contextlogger/contextprovider/jaxws/AbstractTraceeErrorLoggingHandler.java
+++ b/contextprovider/jaxws/src/main/java/io/tracee/contextlogger/contextprovider/jaxws/AbstractTraceeErrorLoggingHandler.java
@@ -1,131 +1,126 @@
 package io.tracee.contextlogger.contextprovider.jaxws;
 
-import java.io.ByteArrayOutputStream;
-import java.nio.charset.Charset;
-import java.util.Set;
+import io.tracee.contextlogger.MessagePrefixProvider;
+import io.tracee.contextlogger.TraceeContextLogger;
+import io.tracee.contextlogger.api.internal.MessageLogLevel;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
+import io.tracee.contextlogger.contextprovider.jaxws.contextprovider.JaxWsWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.xml.namespace.QName;
 import javax.xml.soap.SOAPMessage;
 import javax.xml.ws.handler.MessageContext;
 import javax.xml.ws.handler.soap.SOAPHandler;
 import javax.xml.ws.handler.soap.SOAPMessageContext;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import io.tracee.contextlogger.MessagePrefixProvider;
-import io.tracee.contextlogger.TraceeContextLogger;
-import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
-import io.tracee.contextlogger.api.internal.MessageLogLevel;
-import io.tracee.contextlogger.contextprovider.jaxws.contextprovider.JaxWsWrapper;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.Charset;
+import java.util.Set;
 
 /**
  * Abstract base class for detecting JAX-WS related uncaught exceptions and outputting of contextual information.
  */
 public abstract class AbstractTraceeErrorLoggingHandler implements SOAPHandler<SOAPMessageContext> {
 
-    private static final Logger logger = LoggerFactory.getLogger(AbstractTraceeErrorLoggingHandler.class);
+	private static final Logger logger = LoggerFactory.getLogger(AbstractTraceeErrorLoggingHandler.class);
 
-    protected static final ThreadLocal<String> THREAD_LOCAL_SOAP_MESSAGE_STR = new ThreadLocal<String>();
+	protected static final ThreadLocal<String> THREAD_LOCAL_SOAP_MESSAGE_STR = new ThreadLocal<String>();
 
-    /**
-     * The constructor.
-     */
-    AbstractTraceeErrorLoggingHandler() {
-    }
+	/**
+	 * The constructor.
+	 */
+	AbstractTraceeErrorLoggingHandler() {
+	}
 
-    @Override
-    public final boolean handleMessage(final SOAPMessageContext context) {
-        if (this.isOutgoing(context)) {
-            this.handleOutgoing(context);
-        }
-        else {
-            this.handleIncoming(context);
-        }
-        return true;
-    }
+	@Override
+	public final boolean handleMessage(final SOAPMessageContext context) {
+		if (this.isOutgoing(context)) {
+			this.handleOutgoing(context);
+		} else {
+			this.handleIncoming(context);
+		}
+		return true;
+	}
 
-    @Override
-    public final boolean handleFault(SOAPMessageContext context) {
+	@Override
+	public final boolean handleFault(SOAPMessageContext context) {
 
-        // Must pipe out Soap envelope
-        SOAPMessage soapMessage = context.getMessage();
+		// Must pipe out Soap envelope
+		SOAPMessage soapMessage = context.getMessage();
 
-        TraceeContextLogger
-                .create()
-                .enforceOrder()
-                .apply()
-                .logWithPrefixedMessage(MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, "JAX-WS"), ImplicitContext.COMMON,
-                        ImplicitContext.TRACEE, JaxWsWrapper.wrap(THREAD_LOCAL_SOAP_MESSAGE_STR.get(), convertSoapMessageAsString(soapMessage)));
+		TraceeContextLogger
+				.create()
+				.enforceOrder()
+				.apply()
+				.logWithPrefixedMessage(MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, "JAX-WS"), CoreImplicitContextProviders.COMMON,
+						CoreImplicitContextProviders.TRACEE, JaxWsWrapper.wrap(THREAD_LOCAL_SOAP_MESSAGE_STR.get(), convertSoapMessageAsString(soapMessage)));
 
-        return true;
-    }
+		return true;
+	}
 
-    @Override
-    public void close(MessageContext context) {
-        // cleanup thread local request soap message
-        THREAD_LOCAL_SOAP_MESSAGE_STR.remove();
-    }
+	@Override
+	public void close(MessageContext context) {
+		// cleanup thread local request soap message
+		THREAD_LOCAL_SOAP_MESSAGE_STR.remove();
+	}
 
-    @Override
-    public final Set<QName> getHeaders() {
-        return null;
-    }
+	@Override
+	public final Set<QName> getHeaders() {
+		return null;
+	}
 
-    /**
-     * Converts a SOAPMessage instance to string representation.
-     */
-    String convertSoapMessageAsString(SOAPMessage soapMessage) {
-        if (soapMessage == null) {
-            return "null";
-        }
-        try {
-            ByteArrayOutputStream os = new ByteArrayOutputStream();
-            soapMessage.writeTo(os);
-            return new String(os.toByteArray(), determineMessageEncoding(soapMessage));
-        }
-        catch (Exception e) {
-            logger.error("Couldn't create string representation of soapMessage: " + soapMessage.toString());
-            return "ERROR";
-        }
-    }
+	/**
+	 * Converts a SOAPMessage instance to string representation.
+	 */
+	String convertSoapMessageAsString(SOAPMessage soapMessage) {
+		if (soapMessage == null) {
+			return "null";
+		}
+		try {
+			ByteArrayOutputStream os = new ByteArrayOutputStream();
+			soapMessage.writeTo(os);
+			return new String(os.toByteArray(), determineMessageEncoding(soapMessage));
+		} catch (Exception e) {
+			logger.error("Couldn't create string representation of soapMessage: " + soapMessage.toString());
+			return "ERROR";
+		}
+	}
 
-    Charset determineMessageEncoding(SOAPMessage soapMessage) {
-        try {
-            final Object encProp = soapMessage.getProperty(SOAPMessage.CHARACTER_SET_ENCODING);
-            if (encProp != null) {
-                return Charset.forName(String.valueOf(encProp));
-            }
-            return Charset.forName("UTF-8");
-        }
-        catch (Exception e) {
-            return Charset.forName("UTF-8");
-        }
-    }
+	Charset determineMessageEncoding(SOAPMessage soapMessage) {
+		try {
+			final Object encProp = soapMessage.getProperty(SOAPMessage.CHARACTER_SET_ENCODING);
+			if (encProp != null) {
+				return Charset.forName(String.valueOf(encProp));
+			}
+			return Charset.forName("UTF-8");
+		} catch (Exception e) {
+			return Charset.forName("UTF-8");
+		}
+	}
 
-    protected void storeMessageInThreadLocal(SOAPMessageContext context) {
+	protected void storeMessageInThreadLocal(SOAPMessageContext context) {
 
-        // Save soap request message in thread local storage for error logging
-        SOAPMessage soapMessage = context.getMessage();
-        if (soapMessage != null) {
-            String soapMessageAsString = convertSoapMessageAsString(soapMessage);
-            THREAD_LOCAL_SOAP_MESSAGE_STR.set(soapMessageAsString);
-        }
-    }
+		// Save soap request message in thread local storage for error logging
+		SOAPMessage soapMessage = context.getMessage();
+		if (soapMessage != null) {
+			String soapMessageAsString = convertSoapMessageAsString(soapMessage);
+			THREAD_LOCAL_SOAP_MESSAGE_STR.set(soapMessageAsString);
+		}
+	}
 
-    protected abstract void handleIncoming(SOAPMessageContext context);
+	protected abstract void handleIncoming(SOAPMessageContext context);
 
-    protected abstract void handleOutgoing(SOAPMessageContext context);
+	protected abstract void handleOutgoing(SOAPMessageContext context);
 
-    /**
-     * Checks whether is is an incoming or outgoing call.
-     *
-     * @param messageContext the message context
-     * @return true if is outgoing call, otherwise false
-     */
-    private boolean isOutgoing(MessageContext messageContext) {
-        Object outboundBoolean = messageContext.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY);
-        return outboundBoolean != null && (Boolean)outboundBoolean;
-    }
+	/**
+	 * Checks whether is is an incoming or outgoing call.
+	 *
+	 * @param messageContext the message context
+	 * @return true if is outgoing call, otherwise false
+	 */
+	private boolean isOutgoing(MessageContext messageContext) {
+		Object outboundBoolean = messageContext.get(MessageContext.MESSAGE_OUTBOUND_PROPERTY);
+		return outboundBoolean != null && (Boolean) outboundBoolean;
+	}
 
 }

--- a/contextprovider/jaxws/src/main/java/io/tracee/contextlogger/contextprovider/jaxws/contextprovider/JaxWsContextProvider.java
+++ b/contextprovider/jaxws/src/main/java/io/tracee/contextlogger/contextprovider/jaxws/contextprovider/JaxWsContextProvider.java
@@ -1,7 +1,7 @@
 package io.tracee.contextlogger.contextprovider.jaxws.contextprovider;
 
 import io.tracee.contextlogger.contextprovider.api.Order;
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
@@ -10,7 +10,7 @@ import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
  * JaxWsContextProvider context provider.
  */
 @TraceeContextProvider(displayName = "jaxWs", order = Order.JAXWS)
-@ProfileSettings(basic = true, enhanced = true, full = true)
+@ProfileConfig(basic = true, enhanced = true, full = true)
 public class JaxWsContextProvider implements WrappedContextData<JaxWsWrapper> {
 
 	private JaxWsWrapper jaxWsWrapper;
@@ -32,7 +32,7 @@ public class JaxWsContextProvider implements WrappedContextData<JaxWsWrapper> {
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "soapRequest", order = 40)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public final String getSoapRequest() {
 		if (jaxWsWrapper != null) {
 			return jaxWsWrapper.getSoapRequest();
@@ -42,7 +42,7 @@ public class JaxWsContextProvider implements WrappedContextData<JaxWsWrapper> {
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "soapResponse", order = 50)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public final String getSoapResponse() {
 		if (jaxWsWrapper != null) {
 			return jaxWsWrapper.getSoapResponse();

--- a/contextprovider/jaxws/src/test/java/io/tracee/contextlogger/contextprovider/jaxws/TraceeServerErrorLoggingHandlerTest.java
+++ b/contextprovider/jaxws/src/test/java/io/tracee/contextlogger/contextprovider/jaxws/TraceeServerErrorLoggingHandlerTest.java
@@ -1,5 +1,29 @@
 package io.tracee.contextlogger.contextprovider.jaxws;
 
+import io.tracee.contextlogger.MessagePrefixProvider;
+import io.tracee.contextlogger.TraceeContextLogger;
+import io.tracee.contextlogger.api.ConfigBuilder;
+import io.tracee.contextlogger.api.ContextLogger;
+import io.tracee.contextlogger.api.internal.MessageLogLevel;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
+import io.tracee.contextlogger.contextprovider.jaxws.contextprovider.JaxWsWrapper;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.xml.namespace.QName;
+import javax.xml.soap.MessageFactory;
+import javax.xml.soap.SOAPException;
+import javax.xml.soap.SOAPMessage;
+import javax.xml.ws.handler.soap.SOAPMessageContext;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+
+import static io.tracee.contextlogger.contextprovider.jaxws.TraceeServerErrorLoggingHandler.THREAD_LOCAL_SOAP_MESSAGE_STR;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -16,175 +40,148 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 
-import static io.tracee.contextlogger.contextprovider.jaxws.TraceeServerErrorLoggingHandler.THREAD_LOCAL_SOAP_MESSAGE_STR;
-
-import java.io.OutputStream;
-import java.nio.charset.Charset;
-
-import javax.xml.namespace.QName;
-import javax.xml.soap.MessageFactory;
-import javax.xml.soap.SOAPException;
-import javax.xml.soap.SOAPMessage;
-import javax.xml.ws.handler.soap.SOAPMessageContext;
-
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-
-import io.tracee.contextlogger.MessagePrefixProvider;
-import io.tracee.contextlogger.TraceeContextLogger;
-import io.tracee.contextlogger.api.ConfigBuilder;
-import io.tracee.contextlogger.api.ContextLogger;
-import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
-import io.tracee.contextlogger.api.internal.MessageLogLevel;
-import io.tracee.contextlogger.contextprovider.jaxws.contextprovider.JaxWsWrapper;
-
 /**
  * Test class for {@link AbstractTraceeErrorLoggingHandler} and {@link TraceeServerErrorLoggingHandler}.
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ TraceeContextLogger.class, MessagePrefixProvider.class })
+@PrepareForTest({TraceeContextLogger.class, MessagePrefixProvider.class})
 public class TraceeServerErrorLoggingHandlerTest {
 
-    private final static String LOG_MESSAGE_PREFIX = "XX";
+	private final static String LOG_MESSAGE_PREFIX = "XX";
 
-    private TraceeServerErrorLoggingHandler unit;
-    private TraceeContextLogger contextLogger;
-    private final ConfigBuilder<ContextLogger> configBuilder = mock(ConfigBuilder.class);
+	private TraceeServerErrorLoggingHandler unit;
+	private TraceeContextLogger contextLogger;
+	private final ConfigBuilder<ContextLogger> configBuilder = mock(ConfigBuilder.class);
 
-    @Before
-    public void setup() {
-        unit = new TraceeServerErrorLoggingHandler();
-        THREAD_LOCAL_SOAP_MESSAGE_STR.remove();
+	@Before
+	public void setup() {
+		unit = new TraceeServerErrorLoggingHandler();
+		THREAD_LOCAL_SOAP_MESSAGE_STR.remove();
 
-        // Stuff for TraceeServerErrorLoggingHandler.handleFault()
-        mockStatic(TraceeContextLogger.class);
-        contextLogger = mock(TraceeContextLogger.class);
-        when(TraceeContextLogger.create()).thenReturn(configBuilder);
-        when(configBuilder.enforceOrder()).thenReturn(configBuilder);
-        when(configBuilder.apply()).thenReturn(contextLogger);
+		// Stuff for TraceeServerErrorLoggingHandler.handleFault()
+		mockStatic(TraceeContextLogger.class);
+		contextLogger = mock(TraceeContextLogger.class);
+		when(TraceeContextLogger.create()).thenReturn(configBuilder);
+		when(configBuilder.enforceOrder()).thenReturn(configBuilder);
+		when(configBuilder.apply()).thenReturn(contextLogger);
 
-        // mock log message prefix creation
-        mockStatic(MessagePrefixProvider.class);
-        when(MessagePrefixProvider.provideLogMessagePrefix(Mockito.any(MessageLogLevel.class), Mockito.any(String.class))).thenReturn(LOG_MESSAGE_PREFIX);
-        when(MessagePrefixProvider.provideLogMessagePrefix(Mockito.any(MessageLogLevel.class), Mockito.any(Class.class))).thenReturn(LOG_MESSAGE_PREFIX);
-    }
+		// mock log message prefix creation
+		mockStatic(MessagePrefixProvider.class);
+		when(MessagePrefixProvider.provideLogMessagePrefix(Mockito.any(MessageLogLevel.class), Mockito.any(String.class))).thenReturn(LOG_MESSAGE_PREFIX);
+		when(MessagePrefixProvider.provideLogMessagePrefix(Mockito.any(MessageLogLevel.class), Mockito.any(Class.class))).thenReturn(LOG_MESSAGE_PREFIX);
+	}
 
-    @Test
-    public void defaultConstructorShouldUseTraceeBackend() {
-        new TraceeServerErrorLoggingHandler();
-        // Verification of call Tracee.getBackend:
-        verifyStatic();
-    }
+	@Test
+	public void defaultConstructorShouldUseTraceeBackend() {
+		new TraceeServerErrorLoggingHandler();
+		// Verification of call Tracee.getBackend:
+		verifyStatic();
+	}
 
-    @Test
-    public void shouldConvertNullMessageToNullString() {
-        assertThat(unit.convertSoapMessageAsString(null), equalTo("null"));
-    }
+	@Test
+	public void shouldConvertNullMessageToNullString() {
+		assertThat(unit.convertSoapMessageAsString(null), equalTo("null"));
+	}
 
-    @Test
-    public void shouldConvertSoapMessageToString() throws Exception {
-        final SOAPMessage message = buildSpiedTestMessage("vÄ");
+	@Test
+	public void shouldConvertSoapMessageToString() throws Exception {
+		final SOAPMessage message = buildSpiedTestMessage("vÄ");
 
-        assertThat(unit.convertSoapMessageAsString(message),
-                Matchers.allOf(containsString("SOAP-ENV:Body A=\"vÄ\"/>"), containsString("SOAP-ENV:Envelope")));
-    }
+		assertThat(unit.convertSoapMessageAsString(message),
+				Matchers.allOf(containsString("SOAP-ENV:Body A=\"vÄ\"/>"), containsString("SOAP-ENV:Envelope")));
+	}
 
-    @Test
-    public void messageShouldBeWrittenToThreadLocal() throws Exception {
-        SOAPMessageContext context = mock(SOAPMessageContext.class);
-        when(context.getMessage()).thenReturn(buildSpiedTestMessage("vÄ"));
-        unit.handleIncoming(context);
-        assertThat(THREAD_LOCAL_SOAP_MESSAGE_STR.get(),
-                Matchers.allOf(notNullValue(), containsString("SOAP-ENV:Body A=\"vÄ\"/>"), containsString("SOAP-ENV:Envelope")));
-    }
+	@Test
+	public void messageShouldBeWrittenToThreadLocal() throws Exception {
+		SOAPMessageContext context = mock(SOAPMessageContext.class);
+		when(context.getMessage()).thenReturn(buildSpiedTestMessage("vÄ"));
+		unit.handleIncoming(context);
+		assertThat(THREAD_LOCAL_SOAP_MESSAGE_STR.get(),
+				Matchers.allOf(notNullValue(), containsString("SOAP-ENV:Body A=\"vÄ\"/>"), containsString("SOAP-ENV:Envelope")));
+	}
 
-    @Test
-    public void messageShouldBeWrittenToThreadLocalAndRespectEncoding() throws Exception {
-        SOAPMessageContext context = mock(SOAPMessageContext.class);
-        SOAPMessage soapMessage = buildSpiedTestMessage("vř");
-        soapMessage.setProperty(SOAPMessage.CHARACTER_SET_ENCODING, "ISO-8859-2");
-        when(context.getMessage()).thenReturn(soapMessage);
+	@Test
+	public void messageShouldBeWrittenToThreadLocalAndRespectEncoding() throws Exception {
+		SOAPMessageContext context = mock(SOAPMessageContext.class);
+		SOAPMessage soapMessage = buildSpiedTestMessage("vř");
+		soapMessage.setProperty(SOAPMessage.CHARACTER_SET_ENCODING, "ISO-8859-2");
+		when(context.getMessage()).thenReturn(soapMessage);
 
-        unit.handleIncoming(context);
-        assertThat(THREAD_LOCAL_SOAP_MESSAGE_STR.get(), Matchers.allOf(notNullValue(), containsString("SOAP-ENV:Body A=\"vř\"/>")));
-    }
+		unit.handleIncoming(context);
+		assertThat(THREAD_LOCAL_SOAP_MESSAGE_STR.get(), Matchers.allOf(notNullValue(), containsString("SOAP-ENV:Body A=\"vř\"/>")));
+	}
 
-    @Test
-    public void useUtf8IfNoEncodingIsSpecified() throws Exception {
-        SOAPMessage soapMessage = buildSpiedTestMessage("vř");
+	@Test
+	public void useUtf8IfNoEncodingIsSpecified() throws Exception {
+		SOAPMessage soapMessage = buildSpiedTestMessage("vř");
 
-        assertThat(unit.determineMessageEncoding(soapMessage), is(Charset.forName("UTF-8")));
-    }
+		assertThat(unit.determineMessageEncoding(soapMessage), is(Charset.forName("UTF-8")));
+	}
 
-    @Test
-    public void useGivenEncodingFromSoapMessage() throws Exception {
-        SOAPMessage soapMessage = buildSpiedTestMessage("vř");
-        soapMessage.setProperty(SOAPMessage.CHARACTER_SET_ENCODING, "ISO-8859-2");
+	@Test
+	public void useGivenEncodingFromSoapMessage() throws Exception {
+		SOAPMessage soapMessage = buildSpiedTestMessage("vř");
+		soapMessage.setProperty(SOAPMessage.CHARACTER_SET_ENCODING, "ISO-8859-2");
 
-        assertThat(unit.determineMessageEncoding(soapMessage), is(Charset.forName("ISO-8859-2")));
-    }
+		assertThat(unit.determineMessageEncoding(soapMessage), is(Charset.forName("ISO-8859-2")));
+	}
 
-    @Test
-    public void fallbackToUtf8IfEncodingisNotSupported() throws Exception {
-        SOAPMessage soapMessage = buildSpiedTestMessage("vř");
-        soapMessage.setProperty(SOAPMessage.CHARACTER_SET_ENCODING, "DonaldDuck");
+	@Test
+	public void fallbackToUtf8IfEncodingisNotSupported() throws Exception {
+		SOAPMessage soapMessage = buildSpiedTestMessage("vř");
+		soapMessage.setProperty(SOAPMessage.CHARACTER_SET_ENCODING, "DonaldDuck");
 
-        assertThat(unit.determineMessageEncoding(soapMessage), is(Charset.forName("UTF-8")));
-    }
+		assertThat(unit.determineMessageEncoding(soapMessage), is(Charset.forName("UTF-8")));
+	}
 
-    @Test
-    public void failedMessageTranslationShouldTranslateToErrorString() throws Exception {
-        SOAPMessage soapMessage = buildSpiedTestMessage("v");
-        doThrow(new RuntimeException("ohoh")).when(soapMessage).writeTo(Mockito.any(OutputStream.class));
-        assertThat(unit.convertSoapMessageAsString(soapMessage), is("ERROR"));
-    }
+	@Test
+	public void failedMessageTranslationShouldTranslateToErrorString() throws Exception {
+		SOAPMessage soapMessage = buildSpiedTestMessage("v");
+		doThrow(new RuntimeException("ohoh")).when(soapMessage).writeTo(Mockito.any(OutputStream.class));
+		assertThat(unit.convertSoapMessageAsString(soapMessage), is("ERROR"));
+	}
 
-    @Test
-    public void closeShouldDeleteThreadLocalStore() throws Exception {
-        THREAD_LOCAL_SOAP_MESSAGE_STR.set("My Value");
-        unit.close(null);
-        assertThat(THREAD_LOCAL_SOAP_MESSAGE_STR.get(), is(nullValue()));
-    }
+	@Test
+	public void closeShouldDeleteThreadLocalStore() throws Exception {
+		THREAD_LOCAL_SOAP_MESSAGE_STR.set("My Value");
+		unit.close(null);
+		assertThat(THREAD_LOCAL_SOAP_MESSAGE_STR.get(), is(nullValue()));
+	}
 
-    @Test
-    public void faultsShouldLogTheSoapMessage() throws Exception {
-        final SOAPMessageContext messageContext = mock(SOAPMessageContext.class);
-        when(messageContext.getMessage()).thenReturn(buildSpiedTestMessage("vA"));
-        unit.handleFault(messageContext);
-        verify(contextLogger).logWithPrefixedMessage(eq(LOG_MESSAGE_PREFIX), eq(ImplicitContext.COMMON), eq(ImplicitContext.TRACEE),
-                Mockito.any(JaxWsWrapper.class));
-    }
+	@Test
+	public void faultsShouldLogTheSoapMessage() throws Exception {
+		final SOAPMessageContext messageContext = mock(SOAPMessageContext.class);
+		when(messageContext.getMessage()).thenReturn(buildSpiedTestMessage("vA"));
+		unit.handleFault(messageContext);
+		verify(contextLogger).logWithPrefixedMessage(eq(LOG_MESSAGE_PREFIX), eq(CoreImplicitContextProviders.COMMON), eq(CoreImplicitContextProviders.TRACEE),
+				Mockito.any(JaxWsWrapper.class));
+	}
 
-    @Test
-    public void handleFouldShouldReturnTrueToProcessWithHandlerChain() throws Exception {
-        final SOAPMessageContext messageContext = mock(SOAPMessageContext.class);
-        when(messageContext.getMessage()).thenReturn(buildSpiedTestMessage("vA"));
-        unit.handleFault(messageContext);
+	@Test
+	public void handleFouldShouldReturnTrueToProcessWithHandlerChain() throws Exception {
+		final SOAPMessageContext messageContext = mock(SOAPMessageContext.class);
+		when(messageContext.getMessage()).thenReturn(buildSpiedTestMessage("vA"));
+		unit.handleFault(messageContext);
 
-        assertThat(unit.handleFault(messageContext), is(true));
-    }
+		assertThat(unit.handleFault(messageContext), is(true));
+	}
 
-    @Test
-    public void outgoingMessageShouldNotBeProcessed() {
-        final SOAPMessageContext messageContext = mock(SOAPMessageContext.class);
-        verifyNoMoreInteractions(messageContext);
-        unit.handleOutgoing(messageContext);
-        assertThat(THREAD_LOCAL_SOAP_MESSAGE_STR.get(), is(nullValue()));
-    }
+	@Test
+	public void outgoingMessageShouldNotBeProcessed() {
+		final SOAPMessageContext messageContext = mock(SOAPMessageContext.class);
+		verifyNoMoreInteractions(messageContext);
+		unit.handleOutgoing(messageContext);
+		assertThat(THREAD_LOCAL_SOAP_MESSAGE_STR.get(), is(nullValue()));
+	}
 
-    @Test
-    public void registerForNoHeaders() {
-        assertThat(unit.getHeaders(), is(nullValue()));
-    }
+	@Test
+	public void registerForNoHeaders() {
+		assertThat(unit.getHeaders(), is(nullValue()));
+	}
 
-    private SOAPMessage buildSpiedTestMessage(String value) throws SOAPException {
-        final SOAPMessage message = MessageFactory.newInstance().createMessage();
-        message.getSOAPBody().addAttribute(new QName("A"), value);
-        return spy(message);
-    }
+	private SOAPMessage buildSpiedTestMessage(String value) throws SOAPException {
+		final SOAPMessage message = MessageFactory.newInstance().createMessage();
+		message.getSOAPBody().addAttribute(new QName("A"), value);
+		return spy(message);
+	}
 }

--- a/contextprovider/servlet/core/src/main/java/io/tracee/contextlogger/contextprovider/servlet/contextprovider/ServletCookieContextProvider.java
+++ b/contextprovider/servlet/core/src/main/java/io/tracee/contextlogger/contextprovider/servlet/contextprovider/ServletCookieContextProvider.java
@@ -1,7 +1,7 @@
 package io.tracee.contextlogger.contextprovider.servlet.contextprovider;
 
 import io.tracee.contextlogger.contextprovider.api.Order;
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
@@ -13,7 +13,7 @@ import javax.servlet.http.Cookie;
  * Created by Tobias Gindler, holisticon AG on 24.01.14.
  */
 @TraceeContextProvider(displayName = "servletCookies", order = Order.SERVLET)
-@ProfileSettings(basic = true, enhanced = true, full = true)
+@ProfileConfig(basic = true, enhanced = true, full = true)
 public final class ServletCookieContextProvider implements WrappedContextData<Cookie> {
 
 	private Cookie cookie;
@@ -39,7 +39,7 @@ public final class ServletCookieContextProvider implements WrappedContextData<Co
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "name", order = 10)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public String getName() {
 		if (cookie != null) {
 			return cookie.getName();
@@ -49,7 +49,7 @@ public final class ServletCookieContextProvider implements WrappedContextData<Co
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "value", order = 20)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public String getValue() {
 		if (cookie != null) {
 			return cookie.getValue();
@@ -59,7 +59,7 @@ public final class ServletCookieContextProvider implements WrappedContextData<Co
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "domain", order = 30)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public String getDomain() {
 		if (cookie != null) {
 			return cookie.getDomain();
@@ -69,7 +69,7 @@ public final class ServletCookieContextProvider implements WrappedContextData<Co
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "path", order = 40)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public String getPath() {
 		if (cookie != null) {
 			return cookie.getPath();
@@ -79,7 +79,7 @@ public final class ServletCookieContextProvider implements WrappedContextData<Co
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "secure", order = 50)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public Boolean getSecure() {
 		if (cookie != null) {
 			return cookie.getSecure();
@@ -89,7 +89,7 @@ public final class ServletCookieContextProvider implements WrappedContextData<Co
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "max-age", order = 60)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public Integer getMaxAge() {
 		if (cookie != null) {
 			return cookie.getMaxAge();

--- a/contextprovider/servlet/core/src/main/java/io/tracee/contextlogger/contextprovider/servlet/contextprovider/ServletRequestContextProvider.java
+++ b/contextprovider/servlet/core/src/main/java/io/tracee/contextlogger/contextprovider/servlet/contextprovider/ServletRequestContextProvider.java
@@ -1,7 +1,7 @@
 package io.tracee.contextlogger.contextprovider.servlet.contextprovider;
 
 import io.tracee.contextlogger.contextprovider.api.Order;
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
@@ -19,7 +19,7 @@ import java.util.List;
  */
 
 @TraceeContextProvider(displayName = "servletRequest", order = Order.SERVLET)
-@ProfileSettings(basic = true, enhanced = true, full = true)
+@ProfileConfig(basic = true, enhanced = true, full = true)
 public final class ServletRequestContextProvider implements WrappedContextData<HttpServletRequest> {
 
 	private HttpServletRequest request;
@@ -49,7 +49,7 @@ public final class ServletRequestContextProvider implements WrappedContextData<H
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "url", order = 10)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public String getUrl() {
 		if (this.request != null && request.getRequestURL() != null) {
 			return request.getRequestURL().toString();
@@ -59,7 +59,7 @@ public final class ServletRequestContextProvider implements WrappedContextData<H
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "http-method", order = 20)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public String getHttpMethod() {
 		if (this.request != null) {
 			return this.request.getMethod();
@@ -69,7 +69,7 @@ public final class ServletRequestContextProvider implements WrappedContextData<H
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "http-parameters", order = 30)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public List<NameValuePair<String>> getHttpParameters() {
 
 		final List<NameValuePair<String>> list = new ArrayList<NameValuePair<String>>();
@@ -96,7 +96,7 @@ public final class ServletRequestContextProvider implements WrappedContextData<H
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "http-request-headers", order = 40)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public List<NameValuePair<String>> getHttpRequestHeaders() {
 
 		final List<NameValuePair<String>> list = new ArrayList<NameValuePair<String>>();
@@ -117,7 +117,7 @@ public final class ServletRequestContextProvider implements WrappedContextData<H
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "http-request-attributes", order = 45)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public List<NameValuePair<Object>> getHttpRequestAttributes() {
 
 		final List<NameValuePair<Object>> list = new ArrayList<NameValuePair<Object>>();
@@ -138,7 +138,7 @@ public final class ServletRequestContextProvider implements WrappedContextData<H
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "cookies", order = 50)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public List<ServletCookieContextProvider> getCookies() {
 
 		List<ServletCookieContextProvider> wrappedCookies = new ArrayList<ServletCookieContextProvider>();
@@ -154,7 +154,7 @@ public final class ServletRequestContextProvider implements WrappedContextData<H
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "http-remote-address", order = 150)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public String getHttpRemoteAddress() {
 		if (this.request != null) {
 			return request.getRemoteAddr();
@@ -164,7 +164,7 @@ public final class ServletRequestContextProvider implements WrappedContextData<H
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "http-remote-host", order = 160)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public String getHttpRemoteHost() {
 		if (this.request != null) {
 			return this.request.getRemoteHost();
@@ -174,7 +174,7 @@ public final class ServletRequestContextProvider implements WrappedContextData<H
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "http-remote-port", order = 170)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public Integer getHttpRemotePort() {
 		if (this.request != null) {
 			return this.request.getRemotePort();
@@ -184,7 +184,7 @@ public final class ServletRequestContextProvider implements WrappedContextData<H
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "scheme", order = 200)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public String getScheme() {
 		if (this.request != null) {
 			return this.request.getScheme();
@@ -195,7 +195,7 @@ public final class ServletRequestContextProvider implements WrappedContextData<H
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "is-secure", order = 210)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public Boolean getSecure() {
 		if (this.request != null) {
 			return this.request.isSecure();
@@ -206,7 +206,7 @@ public final class ServletRequestContextProvider implements WrappedContextData<H
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "content-type", order = 220)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public String getContentType() {
 		if (this.request != null) {
 			return this.request.getContentType();
@@ -217,7 +217,7 @@ public final class ServletRequestContextProvider implements WrappedContextData<H
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "content-length", order = 230)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public Integer getContentLength() {
 		if (this.request != null) {
 			return this.request.getContentLength();
@@ -227,7 +227,7 @@ public final class ServletRequestContextProvider implements WrappedContextData<H
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "locale", order = 240)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public String getLocale() {
 		if (this.request != null && this.request.getLocale() != null) {
 			return this.request.getLocale().toString();

--- a/contextprovider/servlet/core/src/main/java/io/tracee/contextlogger/contextprovider/servlet/contextprovider/ServletResponseContextProvider.java
+++ b/contextprovider/servlet/core/src/main/java/io/tracee/contextlogger/contextprovider/servlet/contextprovider/ServletResponseContextProvider.java
@@ -1,7 +1,7 @@
 package io.tracee.contextlogger.contextprovider.servlet.contextprovider;
 
 import io.tracee.contextlogger.contextprovider.api.Order;
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
@@ -17,7 +17,7 @@ import java.util.List;
  * Created by Tobias Gindler, holisticon AG on 20.03.14.
  */
 @TraceeContextProvider(displayName = "servletResponse", order = Order.SERVLET)
-@ProfileSettings(basic = true, enhanced = true, full = true)
+@ProfileConfig(basic = true, enhanced = true, full = true)
 public final class ServletResponseContextProvider implements WrappedContextData<HttpServletResponse> {
 
 	private HttpServletResponse response;
@@ -46,7 +46,7 @@ public final class ServletResponseContextProvider implements WrappedContextData<
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "http-status-code", order = 10)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public Integer getHttpStatusCode() {
 		if (this.response != null) {
 			return this.response.getStatus();
@@ -56,7 +56,7 @@ public final class ServletResponseContextProvider implements WrappedContextData<
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "http-header", order = 20)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public List<NameValuePair<String>> getHttpResponseHeaders() {
 		final List<NameValuePair<String>> list = new ArrayList<NameValuePair<String>>();
 

--- a/contextprovider/servlet/core/src/main/java/io/tracee/contextlogger/contextprovider/servlet/contextprovider/ServletSessionContextProvider.java
+++ b/contextprovider/servlet/core/src/main/java/io/tracee/contextlogger/contextprovider/servlet/contextprovider/ServletSessionContextProvider.java
@@ -2,7 +2,7 @@ package io.tracee.contextlogger.contextprovider.servlet.contextprovider;
 
 import io.tracee.contextlogger.contextprovider.api.Order;
 import io.tracee.contextlogger.contextprovider.api.Flatten;
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
@@ -18,7 +18,7 @@ import java.util.List;
  * Created by Tobias Gindler, holisticon AG on 19.03.14.
  */
 @TraceeContextProvider(displayName = "servletSession", order = Order.SERVLET)
-@ProfileSettings(basic = true, enhanced = true, full = true)
+@ProfileConfig(basic = true, enhanced = true, full = true)
 public final class ServletSessionContextProvider implements WrappedContextData<HttpSession> {
 
 	private HttpSession session;
@@ -48,7 +48,7 @@ public final class ServletSessionContextProvider implements WrappedContextData<H
 	@SuppressWarnings("unused")
 	@Flatten
 	@TraceeContextProviderMethod(displayName = "DYNAMIC")
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public List<NameValuePair<Object>> getSessionAttributes() {
 
 		if (session == null) {

--- a/contextprovider/servlet/servlet/src/main/java/io/tracee/contextlogger/contextprovider/servlet/TraceeErrorLoggingFilter.java
+++ b/contextprovider/servlet/servlet/src/main/java/io/tracee/contextlogger/contextprovider/servlet/TraceeErrorLoggingFilter.java
@@ -1,6 +1,9 @@
 package io.tracee.contextlogger.contextprovider.servlet;
 
-import java.io.IOException;
+import io.tracee.contextlogger.MessagePrefixProvider;
+import io.tracee.contextlogger.TraceeContextLogger;
+import io.tracee.contextlogger.api.internal.MessageLogLevel;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -10,11 +13,7 @@ import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import io.tracee.contextlogger.MessagePrefixProvider;
-import io.tracee.contextlogger.TraceeContextLogger;
-import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
-import io.tracee.contextlogger.api.internal.MessageLogLevel;
+import java.io.IOException;
 
 /**
  * Servlet filter to detect uncaught exceptions and to provide some contextual error logs.
@@ -22,50 +21,49 @@ import io.tracee.contextlogger.api.internal.MessageLogLevel;
  */
 public class TraceeErrorLoggingFilter implements Filter {
 
-    @Override
-    public final void init(FilterConfig filterConfig) throws ServletException {
+	@Override
+	public final void init(FilterConfig filterConfig) throws ServletException {
 
-    }
+	}
 
-    @Override
-    public final void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException,
-            ServletException {
+	@Override
+	public final void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException,
+			ServletException {
 
-        try {
-            filterChain.doFilter(servletRequest, servletResponse);
-        }
-        catch (Throwable e) {
+		try {
+			filterChain.doFilter(servletRequest, servletResponse);
+		} catch (Throwable e) {
 
-            if (servletRequest instanceof HttpServletRequest) {
-                handleHttpServletRequest((HttpServletRequest)servletRequest, (HttpServletResponse)servletResponse, e);
-            }
+			if (servletRequest instanceof HttpServletRequest) {
+				handleHttpServletRequest((HttpServletRequest) servletRequest, (HttpServletResponse) servletResponse, e);
+			}
 
-            // now rethrow error
-            if (e instanceof IOException) {
-                throw (IOException)e;
-            }
-            if (e instanceof ServletException) {
-                throw (ServletException)e;
-            }
+			// now rethrow error
+			if (e instanceof IOException) {
+				throw (IOException) e;
+			}
+			if (e instanceof ServletException) {
+				throw (ServletException) e;
+			}
 
-            // wrap all other kinds of exceptions ...
-            throw new ServletException(e);
-        }
-    }
+			// wrap all other kinds of exceptions ...
+			throw new ServletException(e);
+		}
+	}
 
-    private void handleHttpServletRequest(HttpServletRequest servletRequest, HttpServletResponse servletResponse, Throwable e) {
+	private void handleHttpServletRequest(HttpServletRequest servletRequest, HttpServletResponse servletResponse, Throwable e) {
 
-        TraceeContextLogger
-                .create()
-                .enforceOrder()
-                .apply()
-                .logWithPrefixedMessage(MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, TraceeErrorLoggingFilter.class),
-                        ImplicitContext.COMMON, ImplicitContext.TRACEE, servletRequest, servletResponse, servletRequest.getSession(false), e);
+		TraceeContextLogger
+				.create()
+				.enforceOrder()
+				.apply()
+				.logWithPrefixedMessage(MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, TraceeErrorLoggingFilter.class),
+						CoreImplicitContextProviders.COMMON, CoreImplicitContextProviders.TRACEE, servletRequest, servletResponse, servletRequest.getSession(false), e);
 
-    }
+	}
 
-    @Override
-    public final void destroy() {
+	@Override
+	public final void destroy() {
 
-    }
+	}
 }

--- a/contextprovider/servlet/servlet/src/test/java/io/tracee/contextlogger/contextprovider/servlet/TraceeErrorLoggingFilterTest.java
+++ b/contextprovider/servlet/servlet/src/test/java/io/tracee/contextlogger/contextprovider/servlet/TraceeErrorLoggingFilterTest.java
@@ -1,5 +1,25 @@
 package io.tracee.contextlogger.contextprovider.servlet;
 
+import io.tracee.contextlogger.MessagePrefixProvider;
+import io.tracee.contextlogger.TraceeContextLogger;
+import io.tracee.contextlogger.api.ConfigBuilder;
+import io.tracee.contextlogger.api.ContextLogger;
+import io.tracee.contextlogger.api.internal.MessageLogLevel;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.io.IOException;
+
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.Mockito.doThrow;
@@ -8,113 +28,87 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
-import java.io.IOException;
-
-import javax.servlet.FilterChain;
-import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpSession;
-
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
-
-import io.tracee.contextlogger.MessagePrefixProvider;
-import io.tracee.contextlogger.TraceeContextLogger;
-import io.tracee.contextlogger.api.ConfigBuilder;
-import io.tracee.contextlogger.api.ContextLogger;
-import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
-import io.tracee.contextlogger.api.internal.MessageLogLevel;
-
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({ TraceeContextLogger.class, MessagePrefixProvider.class })
+@PrepareForTest({TraceeContextLogger.class, MessagePrefixProvider.class})
 public class TraceeErrorLoggingFilterTest {
 
-    private final static String LOG_MESSAGE_PREFIX = "XX";
+	private final static String LOG_MESSAGE_PREFIX = "XX";
 
-    private final TraceeErrorLoggingFilter unit = new TraceeErrorLoggingFilter();
-    private final HttpServletRequest request = mock(HttpServletRequest.class);
-    private final HttpServletResponse response = mock(HttpServletResponse.class);
-    private final HttpSession session = mock(HttpSession.class);
-    private final FilterChain filterChain = mock(FilterChain.class);
-    private TraceeContextLogger traceeContextLogger = mock(TraceeContextLogger.class);
-    private final ConfigBuilder<ContextLogger> configBuilder = mock(ConfigBuilder.class);
+	private final TraceeErrorLoggingFilter unit = new TraceeErrorLoggingFilter();
+	private final HttpServletRequest request = mock(HttpServletRequest.class);
+	private final HttpServletResponse response = mock(HttpServletResponse.class);
+	private final HttpSession session = mock(HttpSession.class);
+	private final FilterChain filterChain = mock(FilterChain.class);
+	private TraceeContextLogger traceeContextLogger = mock(TraceeContextLogger.class);
+	private final ConfigBuilder<ContextLogger> configBuilder = mock(ConfigBuilder.class);
 
-    @Before
-    public void setUpMocks() {
-        // mock log message prefix creation
-        mockStatic(MessagePrefixProvider.class);
-        when(MessagePrefixProvider.provideLogMessagePrefix(Mockito.any(MessageLogLevel.class), Mockito.any(String.class))).thenReturn(LOG_MESSAGE_PREFIX);
-        when(MessagePrefixProvider.provideLogMessagePrefix(Mockito.any(MessageLogLevel.class), Mockito.any(Class.class))).thenReturn(LOG_MESSAGE_PREFIX);
+	@Before
+	public void setUpMocks() {
+		// mock log message prefix creation
+		mockStatic(MessagePrefixProvider.class);
+		when(MessagePrefixProvider.provideLogMessagePrefix(Mockito.any(MessageLogLevel.class), Mockito.any(String.class))).thenReturn(LOG_MESSAGE_PREFIX);
+		when(MessagePrefixProvider.provideLogMessagePrefix(Mockito.any(MessageLogLevel.class), Mockito.any(Class.class))).thenReturn(LOG_MESSAGE_PREFIX);
 
-        mockStatic(TraceeContextLogger.class);
-        when(TraceeContextLogger.create()).thenReturn(configBuilder);
-        when(configBuilder.enforceOrder()).thenReturn(configBuilder);
-        when(configBuilder.apply()).thenReturn(traceeContextLogger);
-        when(request.getSession(false)).thenReturn(session);
-    }
+		mockStatic(TraceeContextLogger.class);
+		when(TraceeContextLogger.create()).thenReturn(configBuilder);
+		when(configBuilder.enforceOrder()).thenReturn(configBuilder);
+		when(configBuilder.apply()).thenReturn(traceeContextLogger);
+		when(request.getSession(false)).thenReturn(session);
+	}
 
-    @Test
-    public void isTransparentWhenEverythingIsFine() throws Exception {
-        unit.doFilter(request, response, filterChain);
-        verify(filterChain).doFilter(request, response);
-    }
+	@Test
+	public void isTransparentWhenEverythingIsFine() throws Exception {
+		unit.doFilter(request, response, filterChain);
+		verify(filterChain).doFilter(request, response);
+	}
 
-    @Test(expected = ServletException.class)
-    public void logWholeContextOnException() throws Exception {
-        final ServletException expectedException = new ServletException("test");
-        try {
-            doThrow(expectedException).when(filterChain).doFilter(request, response);
-            unit.doFilter(request, response, filterChain);
-        }
-        catch (Exception e) {
-            verify(traceeContextLogger).logWithPrefixedMessage(LOG_MESSAGE_PREFIX, ImplicitContext.COMMON, ImplicitContext.TRACEE, request, response,
-                    session, expectedException);
-            throw e;
-        }
-    }
+	@Test(expected = ServletException.class)
+	public void logWholeContextOnException() throws Exception {
+		final ServletException expectedException = new ServletException("test");
+		try {
+			doThrow(expectedException).when(filterChain).doFilter(request, response);
+			unit.doFilter(request, response, filterChain);
+		} catch (Exception e) {
+			verify(traceeContextLogger).logWithPrefixedMessage(LOG_MESSAGE_PREFIX, CoreImplicitContextProviders.COMMON, CoreImplicitContextProviders.TRACEE, request, response,
+					session, expectedException);
+			throw e;
+		}
+	}
 
-    @Test(expected = ServletException.class)
-    public void rethrowRuntimeException() throws Exception {
-        final RuntimeException expectedException = new RuntimeException();
-        try {
-            doThrow(expectedException).when(filterChain).doFilter(request, response);
-            unit.doFilter(request, response, filterChain);
-        }
-        catch (ServletException e) {
-            assertThat(e.getRootCause(), sameInstance((Throwable)expectedException));
-            throw e;
-        }
-    }
+	@Test(expected = ServletException.class)
+	public void rethrowRuntimeException() throws Exception {
+		final RuntimeException expectedException = new RuntimeException();
+		try {
+			doThrow(expectedException).when(filterChain).doFilter(request, response);
+			unit.doFilter(request, response, filterChain);
+		} catch (ServletException e) {
+			assertThat(e.getRootCause(), sameInstance((Throwable) expectedException));
+			throw e;
+		}
+	}
 
-    @Test(expected = IOException.class)
-    public void rethrowIOException() throws Exception {
-        final IOException expectedException = new IOException();
-        try {
-            doThrow(expectedException).when(filterChain).doFilter(request, response);
-            unit.doFilter(request, response, filterChain);
-        }
-        catch (IOException e) {
-            assertThat(e, sameInstance(expectedException));
-            throw e;
-        }
-    }
+	@Test(expected = IOException.class)
+	public void rethrowIOException() throws Exception {
+		final IOException expectedException = new IOException();
+		try {
+			doThrow(expectedException).when(filterChain).doFilter(request, response);
+			unit.doFilter(request, response, filterChain);
+		} catch (IOException e) {
+			assertThat(e, sameInstance(expectedException));
+			throw e;
+		}
+	}
 
-    @Test(expected = ServletException.class)
-    public void rethrowServletException() throws Exception {
-        final ServletException expectedException = new ServletException();
-        try {
-            doThrow(expectedException).when(filterChain).doFilter(request, response);
-            unit.doFilter(request, response, filterChain);
-        }
-        catch (ServletException e) {
-            assertThat(e, sameInstance(expectedException));
-            throw e;
-        }
-    }
+	@Test(expected = ServletException.class)
+	public void rethrowServletException() throws Exception {
+		final ServletException expectedException = new ServletException();
+		try {
+			doThrow(expectedException).when(filterChain).doFilter(request, response);
+			unit.doFilter(request, response, filterChain);
+		} catch (ServletException e) {
+			assertThat(e, sameInstance(expectedException));
+			throw e;
+		}
+	}
 
 }

--- a/contextprovider/springmvc/src/main/java/io/tracee/contextlogger/contextprovider/springmvc/TraceeContextLoggerHandlerInterceptor.java
+++ b/contextprovider/springmvc/src/main/java/io/tracee/contextlogger/contextprovider/springmvc/TraceeContextLoggerHandlerInterceptor.java
@@ -1,45 +1,44 @@
 package io.tracee.contextlogger.contextprovider.springmvc;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-
+import io.tracee.contextlogger.MessagePrefixProvider;
+import io.tracee.contextlogger.TraceeContextLogger;
+import io.tracee.contextlogger.api.internal.MessageLogLevel;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
 
-import io.tracee.contextlogger.MessagePrefixProvider;
-import io.tracee.contextlogger.TraceeContextLogger;
-import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
-import io.tracee.contextlogger.api.internal.MessageLogLevel;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 public class TraceeContextLoggerHandlerInterceptor implements HandlerInterceptor {
 
-    @Override
-    public boolean preHandle(final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse, final Object o) throws Exception {
-        return true;
-    }
+	@Override
+	public boolean preHandle(final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse, final Object o) throws Exception {
+		return true;
+	}
 
-    @Override
-    public void postHandle(final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse, final Object o,
-            final ModelAndView modelAndView) throws Exception {
+	@Override
+	public void postHandle(final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse, final Object o,
+						   final ModelAndView modelAndView) throws Exception {
 
-    }
+	}
 
-    @Override
-    public void afterCompletion(final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse, final Object o,
-            final Exception e) throws Exception {
+	@Override
+	public void afterCompletion(final HttpServletRequest httpServletRequest, final HttpServletResponse httpServletResponse, final Object o,
+								final Exception e) throws Exception {
 
-        // Output context data in case of an exception
-        if (e != null) {
+		// Output context data in case of an exception
+		if (e != null) {
 
-            TraceeContextLogger
-                    .create()
-                    .enforceOrder()
-                    .apply()
-                    .logWithPrefixedMessage(MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, TraceeContextLoggerHandlerInterceptor.class),
-                            ImplicitContext.COMMON, ImplicitContext.TRACEE, o, httpServletRequest, httpServletResponse,
-                            httpServletRequest.getSession(false), e);
+			TraceeContextLogger
+					.create()
+					.enforceOrder()
+					.apply()
+					.logWithPrefixedMessage(MessagePrefixProvider.provideLogMessagePrefix(MessageLogLevel.ERROR, TraceeContextLoggerHandlerInterceptor.class),
+							CoreImplicitContextProviders.COMMON, CoreImplicitContextProviders.TRACEE, o, httpServletRequest, httpServletResponse,
+							httpServletRequest.getSession(false), e);
 
-        }
+		}
 
-    }
+	}
 }

--- a/contextprovider/springmvc/src/main/java/io/tracee/contextlogger/contextprovider/springmvc/contextprovider/HandlerMethodContextProvider.java
+++ b/contextprovider/springmvc/src/main/java/io/tracee/contextlogger/contextprovider/springmvc/contextprovider/HandlerMethodContextProvider.java
@@ -1,6 +1,6 @@
 package io.tracee.contextlogger.contextprovider.springmvc.contextprovider;
 
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
@@ -14,7 +14,7 @@ import java.util.List;
  * Context provider for {@link HandlerMethod}.
  */
 @TraceeContextProvider(displayName = "handlerMethod")
-@ProfileSettings(basic = true, enhanced = true, full = true)
+@ProfileConfig(basic = true, enhanced = true, full = true)
 public class HandlerMethodContextProvider implements WrappedContextData<HandlerMethod> {
 
 	private HandlerMethod handlerMethod;
@@ -48,7 +48,7 @@ public class HandlerMethodContextProvider implements WrappedContextData<HandlerM
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "type", order = 20)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public final String getType() {
 		if (handlerMethod != null && handlerMethod.getBeanType() != null) {
 			return handlerMethod.getBeanType().getCanonicalName();
@@ -58,7 +58,7 @@ public class HandlerMethodContextProvider implements WrappedContextData<HandlerM
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "method", order = 30)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public final String getMethod() {
 		if (handlerMethod != null && handlerMethod.getMethod() != null) {
 			return handlerMethod.getMethod().getName();
@@ -68,7 +68,7 @@ public class HandlerMethodContextProvider implements WrappedContextData<HandlerM
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "parameters", order = 40)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public final List<MethodParameter> getParameters() {
 
 		if (handlerMethod != null && handlerMethod.getMethodParameters() != null) {
@@ -82,7 +82,7 @@ public class HandlerMethodContextProvider implements WrappedContextData<HandlerM
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "serialized-target-instance", order = 50)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public final Object getSerializedTargetInstance() {
 		if (handlerMethod != null) {
 			// output invoked instance

--- a/contextprovider/springmvc/src/main/java/io/tracee/contextlogger/contextprovider/springmvc/contextprovider/MethodParameterContextProvider.java
+++ b/contextprovider/springmvc/src/main/java/io/tracee/contextlogger/contextprovider/springmvc/contextprovider/MethodParameterContextProvider.java
@@ -1,6 +1,6 @@
 package io.tracee.contextlogger.contextprovider.springmvc.contextprovider;
 
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
@@ -10,7 +10,7 @@ import org.springframework.core.MethodParameter;
  * Context provider dor {@link MethodParameter}.
  */
 @TraceeContextProvider(displayName = "methodParameter")
-@ProfileSettings(basic = true, enhanced = true, full = true)
+@ProfileConfig(basic = true, enhanced = true, full = true)
 public class MethodParameterContextProvider implements WrappedContextData<MethodParameter> {
 
 	private MethodParameter methodParameter;
@@ -44,7 +44,7 @@ public class MethodParameterContextProvider implements WrappedContextData<Method
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "type", order = 20)
-	@ProfileSettings(basic = true, enhanced = true, full = true)
+	@ProfileConfig(basic = true, enhanced = true, full = true)
 	public final String getType() {
 		if (methodParameter != null && methodParameter.getParameterType() != null) {
 			return methodParameter.getParameterType().getCanonicalName();

--- a/core/src/test/java/io/tracee/contextlogger/TestMain.java
+++ b/core/src/test/java/io/tracee/contextlogger/TestMain.java
@@ -1,17 +1,17 @@
 package io.tracee.contextlogger;
 
-import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
 
 /**
  * Created by TGI on 30.01.2015.
  */
 public class TestMain {
 
-    public static void main(String[] args) {
+	public static void main(String[] args) {
 
-        TraceeContextLogger.createDefault().logWithPrefixedMessage("ABC", "DEF", ImplicitContext.COMMON, ImplicitContext.TRACEE);
-		TraceeContextLogger.createDefault().log("ABC", "DEF", ImplicitContext.COMMON, ImplicitContext.TRACEE);
+		TraceeContextLogger.createDefault().logWithPrefixedMessage("ABC", "DEF", CoreImplicitContextProviders.COMMON, CoreImplicitContextProviders.TRACEE);
+		TraceeContextLogger.createDefault().log("ABC", "DEF", CoreImplicitContextProviders.COMMON, CoreImplicitContextProviders.TRACEE);
 
-    }
+	}
 
 }

--- a/core/src/test/java/io/tracee/contextlogger/impl/ContextLoggerConfigurationTest.java
+++ b/core/src/test/java/io/tracee/contextlogger/impl/ContextLoggerConfigurationTest.java
@@ -1,14 +1,13 @@
 package io.tracee.contextlogger.impl;
 
 import io.tracee.contextlogger.contextprovider.api.Profile;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
+import io.tracee.contextlogger.contextprovider.core.java.JavaThrowableContextProvider;
+import io.tracee.contextlogger.profile.ProfilePropertyNames;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Test;
-
-import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
-import io.tracee.contextlogger.contextprovider.core.java.JavaThrowableContextProvider;
-import io.tracee.contextlogger.profile.ProfilePropertyNames;
 
 /**
  * Test class for {@link ContextLoggerConfiguration}.
@@ -16,76 +15,76 @@ import io.tracee.contextlogger.profile.ProfilePropertyNames;
  */
 public class ContextLoggerConfigurationTest {
 
-    @Before
-    public void init() {
-        System.setProperty(ProfilePropertyNames.PROFILE_SET_GLOBALLY_VIA_SYSTEM_PROPERTIES, Profile.BASIC.name());
-    }
+	@Before
+	public void init() {
+		System.setProperty(ProfilePropertyNames.PROFILE_SET_GLOBALLY_VIA_SYSTEM_PROPERTIES, Profile.BASIC.name());
+	}
 
-    @Test
-    public void should_get_context_logger_configuration() {
+	@Test
+	public void should_get_context_logger_configuration() {
 
-        ContextLoggerConfiguration contextLoggerConfiguration = ContextLoggerConfiguration.getOrCreateContextLoggerConfiguration();
+		ContextLoggerConfiguration contextLoggerConfiguration = ContextLoggerConfiguration.getOrCreateContextLoggerConfiguration();
 
-        MatcherAssert.assertThat(contextLoggerConfiguration, Matchers.notNullValue());
+		MatcherAssert.assertThat(contextLoggerConfiguration, Matchers.notNullValue());
 
-    }
+	}
 
-    @Test
-    public void should_get_implicit_wrapper_list_of_context_logger_configuration() {
+	@Test
+	public void should_get_implicit_wrapper_list_of_context_logger_configuration() {
 
-        ContextLoggerConfiguration contextLoggerConfiguration = ContextLoggerConfiguration.getOrCreateContextLoggerConfiguration();
+		ContextLoggerConfiguration contextLoggerConfiguration = ContextLoggerConfiguration.getOrCreateContextLoggerConfiguration();
 
-        MatcherAssert.assertThat(contextLoggerConfiguration, Matchers.notNullValue());
-        MatcherAssert.assertThat(contextLoggerConfiguration.getImplicitContextClassMap(), Matchers.notNullValue());
-        MatcherAssert.assertThat(contextLoggerConfiguration.getImplicitContextClassMap().containsKey(ImplicitContext.COMMON), Matchers.equalTo(true));
-        MatcherAssert.assertThat(contextLoggerConfiguration.getImplicitContextClassMap().containsKey(ImplicitContext.TRACEE), Matchers.equalTo(true));
+		MatcherAssert.assertThat(contextLoggerConfiguration, Matchers.notNullValue());
+		MatcherAssert.assertThat(contextLoggerConfiguration.getImplicitContextClassMap(), Matchers.notNullValue());
+		MatcherAssert.assertThat(contextLoggerConfiguration.getImplicitContextClassMap().containsKey(CoreImplicitContextProviders.COMMON), Matchers.equalTo(true));
+		MatcherAssert.assertThat(contextLoggerConfiguration.getImplicitContextClassMap().containsKey(CoreImplicitContextProviders.TRACEE), Matchers.equalTo(true));
 
-    }
+	}
 
-    @Test
-    public void should_get_wrapper_class_mapping_of_context_logger_configuration() {
+	@Test
+	public void should_get_wrapper_class_mapping_of_context_logger_configuration() {
 
-        ContextLoggerConfiguration contextLoggerConfiguration = ContextLoggerConfiguration.getOrCreateContextLoggerConfiguration();
+		ContextLoggerConfiguration contextLoggerConfiguration = ContextLoggerConfiguration.getOrCreateContextLoggerConfiguration();
 
-        MatcherAssert.assertThat(contextLoggerConfiguration, Matchers.notNullValue());
-        MatcherAssert.assertThat(contextLoggerConfiguration.getClassToWrapperMap(), Matchers.notNullValue());
-        MatcherAssert.assertThat(contextLoggerConfiguration.getClassToWrapperMap().containsKey(Throwable.class), Matchers.equalTo(true));
-        MatcherAssert.assertThat(contextLoggerConfiguration.getClassToWrapperMap().get(Throwable.class).equals(JavaThrowableContextProvider.class),
-                Matchers.equalTo(true));
+		MatcherAssert.assertThat(contextLoggerConfiguration, Matchers.notNullValue());
+		MatcherAssert.assertThat(contextLoggerConfiguration.getClassToWrapperMap(), Matchers.notNullValue());
+		MatcherAssert.assertThat(contextLoggerConfiguration.getClassToWrapperMap().containsKey(Throwable.class), Matchers.equalTo(true));
+		MatcherAssert.assertThat(contextLoggerConfiguration.getClassToWrapperMap().get(Throwable.class).equals(JavaThrowableContextProvider.class),
+				Matchers.equalTo(true));
 
-    }
+	}
 
-    @Test
-    public void should_get_profile_of_context_logger_configuration() {
+	@Test
+	public void should_get_profile_of_context_logger_configuration() {
 
-        ContextLoggerConfiguration contextLoggerConfiguration = ContextLoggerConfiguration.getOrCreateContextLoggerConfiguration();
+		ContextLoggerConfiguration contextLoggerConfiguration = ContextLoggerConfiguration.getOrCreateContextLoggerConfiguration();
 
-        MatcherAssert.assertThat(contextLoggerConfiguration, Matchers.notNullValue());
-        MatcherAssert.assertThat(contextLoggerConfiguration.getProfile(), Matchers.notNullValue());
-        MatcherAssert.assertThat(contextLoggerConfiguration.getProfile(), Matchers.equalTo(Profile.BASIC));
+		MatcherAssert.assertThat(contextLoggerConfiguration, Matchers.notNullValue());
+		MatcherAssert.assertThat(contextLoggerConfiguration.getProfile(), Matchers.notNullValue());
+		MatcherAssert.assertThat(contextLoggerConfiguration.getProfile(), Matchers.equalTo(Profile.BASIC));
 
-    }
+	}
 
-    @Test
-    public void should_get_wrapper_classes_of_context_logger_configuration() {
+	@Test
+	public void should_get_wrapper_classes_of_context_logger_configuration() {
 
-        ContextLoggerConfiguration contextLoggerConfiguration = ContextLoggerConfiguration.getOrCreateContextLoggerConfiguration();
+		ContextLoggerConfiguration contextLoggerConfiguration = ContextLoggerConfiguration.getOrCreateContextLoggerConfiguration();
 
-        MatcherAssert.assertThat(contextLoggerConfiguration, Matchers.notNullValue());
-        MatcherAssert.assertThat(contextLoggerConfiguration.getWrapperClasses(), Matchers.notNullValue());
-        MatcherAssert.assertThat(contextLoggerConfiguration.getWrapperClasses().contains(JavaThrowableContextProvider.class), Matchers.equalTo(true));
+		MatcherAssert.assertThat(contextLoggerConfiguration, Matchers.notNullValue());
+		MatcherAssert.assertThat(contextLoggerConfiguration.getWrapperClasses(), Matchers.notNullValue());
+		MatcherAssert.assertThat(contextLoggerConfiguration.getWrapperClasses().contains(JavaThrowableContextProvider.class), Matchers.equalTo(true));
 
-    }
+	}
 
-    @Test
-    public void should_get_wrappers_of_context_logger_configuration() {
+	@Test
+	public void should_get_wrappers_of_context_logger_configuration() {
 
-        ContextLoggerConfiguration contextLoggerConfiguration = ContextLoggerConfiguration.getOrCreateContextLoggerConfiguration();
+		ContextLoggerConfiguration contextLoggerConfiguration = ContextLoggerConfiguration.getOrCreateContextLoggerConfiguration();
 
-        MatcherAssert.assertThat(contextLoggerConfiguration, Matchers.notNullValue());
+		MatcherAssert.assertThat(contextLoggerConfiguration, Matchers.notNullValue());
 
-        MatcherAssert.assertThat(contextLoggerConfiguration.getWrapperList(), Matchers.notNullValue());
-        MatcherAssert.assertThat(contextLoggerConfiguration.getWrapperList().size(), Matchers.greaterThan(0));
-    }
+		MatcherAssert.assertThat(contextLoggerConfiguration.getWrapperList(), Matchers.notNullValue());
+		MatcherAssert.assertThat(contextLoggerConfiguration.getWrapperList().size(), Matchers.greaterThan(0));
+	}
 
 }

--- a/core/src/test/java/io/tracee/contextlogger/outputgenerator/functions/TraceeContextProviderWrapperFunctionTest.java
+++ b/core/src/test/java/io/tracee/contextlogger/outputgenerator/functions/TraceeContextProviderWrapperFunctionTest.java
@@ -1,192 +1,192 @@
 package io.tracee.contextlogger.outputgenerator.functions;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.mockito.Mockito.when;
+import io.tracee.contextlogger.contextprovider.TypeToWrapper;
+import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
+import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
+import io.tracee.contextlogger.impl.ContextLoggerConfiguration;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.hamcrest.Matchers;
-import org.junit.Before;
-import org.junit.Test;
-import org.mockito.Mockito;
-
-import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
-import io.tracee.contextlogger.contextprovider.TypeToWrapper;
-import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
-import io.tracee.contextlogger.impl.ContextLoggerConfiguration;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit test for {@link TraceeContextProviderWrapperFunction}.
  */
 public class TraceeContextProviderWrapperFunctionTest {
 
-    private ContextLoggerConfiguration contextLoggerConfiguration = Mockito.mock(ContextLoggerConfiguration.class);
+	private ContextLoggerConfiguration contextLoggerConfiguration = Mockito.mock(ContextLoggerConfiguration.class);
 
-    private TraceeContextProviderWrapperFunction unit = TraceeContextProviderWrapperFunction.getInstance();
+	private TraceeContextProviderWrapperFunction unit = TraceeContextProviderWrapperFunction.getInstance();
 
-    public static class ClassWithNoNoargConstructor {
+	public static class ClassWithNoNoargConstructor {
 
-        public ClassWithNoNoargConstructor(String xyz) {
+		public ClassWithNoNoargConstructor(String xyz) {
 
-        }
+		}
 
-    }
+	}
 
-    public static class UnmappedClass {
+	public static class UnmappedClass {
 
-    }
+	}
 
-    public static class MappedClass {
+	public static class MappedClass {
 
-    }
+	}
 
-    public static class MappedClassWrapper implements WrappedContextData<MappedClass> {
+	public static class MappedClassWrapper implements WrappedContextData<MappedClass> {
 
-        private MappedClass instance;
+		private MappedClass instance;
 
-        @Override
-        public void setContextData(final Object instance) throws ClassCastException {
-            this.instance = (MappedClass)instance;
-        }
+		@Override
+		public void setContextData(final Object instance) throws ClassCastException {
+			this.instance = (MappedClass) instance;
+		}
 
-        @Override
-        public MappedClass getContextData() {
-            return this.instance;
-        }
+		@Override
+		public MappedClass getContextData() {
+			return this.instance;
+		}
 
-        @Override
-        public Class getWrappedType() {
-            return MappedClass.class;
-        }
-    }
+		@Override
+		public Class getWrappedType() {
+			return MappedClass.class;
+		}
+	}
 
-    public static class IncorrectMappedClass {
+	public static class IncorrectMappedClass {
 
-    }
+	}
 
-    public static class IncorrectMappedClassWrapper {
+	public static class IncorrectMappedClassWrapper {
 
-    }
+	}
 
-    public static class WrappedTypeListType {
+	public static class WrappedTypeListType {
 
-    }
+	}
 
-    public static class WrappedTypeListTypeWrapper implements WrappedContextData<WrappedTypeListType> {
+	public static class WrappedTypeListTypeWrapper implements WrappedContextData<WrappedTypeListType> {
 
-        private WrappedTypeListType instance;
+		private WrappedTypeListType instance;
 
-        @Override
-        public void setContextData(final Object instance) throws ClassCastException {
-            this.instance = (WrappedTypeListType)instance;
-        }
+		@Override
+		public void setContextData(final Object instance) throws ClassCastException {
+			this.instance = (WrappedTypeListType) instance;
+		}
 
-        @Override
-        public WrappedTypeListType getContextData() {
-            return this.instance;
-        }
+		@Override
+		public WrappedTypeListType getContextData() {
+			return this.instance;
+		}
 
-        @Override
-        public Class<WrappedTypeListType> getWrappedType() {
-            return WrappedTypeListType.class;
-        }
-    }
+		@Override
+		public Class<WrappedTypeListType> getWrappedType() {
+			return WrappedTypeListType.class;
+		}
+	}
 
-    @Before
-    public void init() {
+	@Before
+	public void init() {
 
-        Map<ImplicitContext, Class> implicitContextClassMap = new HashMap<ImplicitContext, Class>();
-        implicitContextClassMap.put(ImplicitContext.COMMON, TraceeContextProviderWrapperFunctionTest.class);
+		Map<ImplicitContext, Class> implicitContextClassMap = new HashMap<ImplicitContext, Class>();
+		implicitContextClassMap.put(CoreImplicitContextProviders.COMMON, TraceeContextProviderWrapperFunctionTest.class);
 
-        when(contextLoggerConfiguration.getImplicitContextClassMap()).thenReturn(implicitContextClassMap);
+		when(contextLoggerConfiguration.getImplicitContextClassMap()).thenReturn(implicitContextClassMap);
 
-        Map<Class, Class> classToWrapperMap = new HashMap<Class, Class>();
-        classToWrapperMap.put(MappedClass.class, MappedClassWrapper.class);
-        classToWrapperMap.put(IncorrectMappedClass.class, IncorrectMappedClassWrapper.class);
+		Map<Class, Class> classToWrapperMap = new HashMap<Class, Class>();
+		classToWrapperMap.put(MappedClass.class, MappedClassWrapper.class);
+		classToWrapperMap.put(IncorrectMappedClass.class, IncorrectMappedClassWrapper.class);
 
-        when(contextLoggerConfiguration.getClassToWrapperMap()).thenReturn(classToWrapperMap);
+		when(contextLoggerConfiguration.getClassToWrapperMap()).thenReturn(classToWrapperMap);
 
-        List<TypeToWrapper> typeToWrapperList = new ArrayList<TypeToWrapper>();
-        typeToWrapperList.add(new TypeToWrapper(WrappedTypeListType.class, WrappedTypeListTypeWrapper.class));
+		List<TypeToWrapper> typeToWrapperList = new ArrayList<TypeToWrapper>();
+		typeToWrapperList.add(new TypeToWrapper(WrappedTypeListType.class, WrappedTypeListTypeWrapper.class));
 
-        when(contextLoggerConfiguration.getWrapperList()).thenReturn(typeToWrapperList);
+		when(contextLoggerConfiguration.getWrapperList()).thenReturn(typeToWrapperList);
 
-    }
+	}
 
-    @Test
-    public void apply_should_handle_implicit_context_correctly() {
+	@Test
+	public void apply_should_handle_implicit_context_correctly() {
 
-        Object result = unit.apply(contextLoggerConfiguration, ImplicitContext.COMMON);
-        assertThat(result, Matchers.notNullValue());
-        assertThat(result.getClass(), Matchers.typeCompatibleWith(this.getClass()));
+		Object result = unit.apply(contextLoggerConfiguration, CoreImplicitContextProviders.COMMON);
+		assertThat(result, Matchers.notNullValue());
+		assertThat(result.getClass(), Matchers.typeCompatibleWith(this.getClass()));
 
-    }
+	}
 
-    @Test
-    public void apply_should_handle_known_mapped_context_class_correctly() {
+	@Test
+	public void apply_should_handle_known_mapped_context_class_correctly() {
 
-        Object instance = new MappedClass();
+		Object instance = new MappedClass();
 
-        Object result = unit.apply(contextLoggerConfiguration, instance);
+		Object result = unit.apply(contextLoggerConfiguration, instance);
 
-        assertThat(result, Matchers.notNullValue());
-        assertThat(result.getClass(), Matchers.typeCompatibleWith(MappedClassWrapper.class));
+		assertThat(result, Matchers.notNullValue());
+		assertThat(result.getClass(), Matchers.typeCompatibleWith(MappedClassWrapper.class));
 
-    }
+	}
 
-    @Test
-    public void apply_should_handle_type_to_wrapper_type_correctly() {
+	@Test
+	public void apply_should_handle_type_to_wrapper_type_correctly() {
 
-        Object instance = new WrappedTypeListType();
+		Object instance = new WrappedTypeListType();
 
-        Object result = unit.apply(contextLoggerConfiguration, instance);
+		Object result = unit.apply(contextLoggerConfiguration, instance);
 
-        assertThat(result, Matchers.notNullValue());
-        assertThat(result.getClass(), Matchers.typeCompatibleWith(WrappedTypeListTypeWrapper.class));
+		assertThat(result, Matchers.notNullValue());
+		assertThat(result.getClass(), Matchers.typeCompatibleWith(WrappedTypeListTypeWrapper.class));
 
-    }
+	}
 
-    @Test
-    public void apply_should_handle_broken_known_mapped_context_class_correctly() {
+	@Test
+	public void apply_should_handle_broken_known_mapped_context_class_correctly() {
 
-        Object instance = new IncorrectMappedClass();
+		Object instance = new IncorrectMappedClass();
 
-        Object result = unit.apply(contextLoggerConfiguration, instance);
+		Object result = unit.apply(contextLoggerConfiguration, instance);
 
-        // should return passed instance if mapping is broken
-        assertThat(result, Matchers.notNullValue());
-        assertThat(result, Matchers.is(instance));
+		// should return passed instance if mapping is broken
+		assertThat(result, Matchers.notNullValue());
+		assertThat(result, Matchers.is(instance));
 
-    }
+	}
 
-    @Test
-    public void apply_should_return_passed_instance_if_no_wrapper_can_be_found() {
+	@Test
+	public void apply_should_return_passed_instance_if_no_wrapper_can_be_found() {
 
-        Object instance = new UnmappedClass();
+		Object instance = new UnmappedClass();
 
-        Object result = unit.apply(contextLoggerConfiguration, instance);
-        assertThat(result, Matchers.notNullValue());
-        assertThat(result, Matchers.is(instance));
+		Object result = unit.apply(contextLoggerConfiguration, instance);
+		assertThat(result, Matchers.notNullValue());
+		assertThat(result, Matchers.is(instance));
 
-    }
+	}
 
-    @Test
-    public void createInstance_should_create_instance_correctly() {
-        Object result = unit.createInstance(this.getClass());
+	@Test
+	public void createInstance_should_create_instance_correctly() {
+		Object result = unit.createInstance(this.getClass());
 
-        assertThat(result, Matchers.notNullValue());
-        assertThat(result.getClass(), Matchers.typeCompatibleWith(this.getClass()));
-    }
+		assertThat(result, Matchers.notNullValue());
+		assertThat(result.getClass(), Matchers.typeCompatibleWith(this.getClass()));
+	}
 
-    @Test
-    public void createInstance_should_create_null_for_type_with_no_noarg_constructor() {
+	@Test
+	public void createInstance_should_create_null_for_type_with_no_noarg_constructor() {
 
-        Object result = unit.createInstance(ClassWithNoNoargConstructor.class);
+		Object result = unit.createInstance(ClassWithNoNoargConstructor.class);
 
-        assertThat(result, Matchers.nullValue());
+		assertThat(result, Matchers.nullValue());
 
-    }
+	}
 }

--- a/core/src/test/java/io/tracee/contextlogger/outputgenerator/predicates/IsImplicitContextEnumValuePredicateTest.java
+++ b/core/src/test/java/io/tracee/contextlogger/outputgenerator/predicates/IsImplicitContextEnumValuePredicateTest.java
@@ -1,30 +1,29 @@
 package io.tracee.contextlogger.outputgenerator.predicates;
 
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-
-import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
 
 /**
  * Unit test for {@link io.tracee.contextlogger.outputgenerator.predicates.IsImplicitContextEnumValuePredicate}.
  */
 public class IsImplicitContextEnumValuePredicateTest {
 
-    @Test
-    public void should_detect_implicit_context_enum_value_correctly() {
-        MatcherAssert.assertThat(IsImplicitContextEnumValuePredicate.getInstance().apply(ImplicitContext.COMMON), Matchers.is(true));
-        MatcherAssert.assertThat(IsImplicitContextEnumValuePredicate.getInstance().apply(ImplicitContext.TRACEE), Matchers.is(true));
-    }
+	@Test
+	public void should_detect_implicit_context_enum_value_correctly() {
+		MatcherAssert.assertThat(IsImplicitContextEnumValuePredicate.getInstance().apply(CoreImplicitContextProviders.COMMON), Matchers.is(true));
+		MatcherAssert.assertThat(IsImplicitContextEnumValuePredicate.getInstance().apply(CoreImplicitContextProviders.TRACEE), Matchers.is(true));
+	}
 
-    @Test
-    public void should_detect_non_implicit_context_enum_value_correctly() {
-        MatcherAssert.assertThat(IsImplicitContextEnumValuePredicate.getInstance().apply(this), Matchers.is(false));
-    }
+	@Test
+	public void should_detect_non_implicit_context_enum_value_correctly() {
+		MatcherAssert.assertThat(IsImplicitContextEnumValuePredicate.getInstance().apply(this), Matchers.is(false));
+	}
 
-    @Test
-    public void should_handle_null_value_correctly() {
-        MatcherAssert.assertThat(IsImplicitContextEnumValuePredicate.getInstance().apply(null), Matchers.is(false));
-    }
+	@Test
+	public void should_handle_null_value_correctly() {
+		MatcherAssert.assertThat(IsImplicitContextEnumValuePredicate.getInstance().apply(null), Matchers.is(false));
+	}
 
 }

--- a/integration-test/general/src/main/java/io/tracee/contextlogger/integrationtest/DemoHttpServer.java
+++ b/integration-test/general/src/main/java/io/tracee/contextlogger/integrationtest/DemoHttpServer.java
@@ -10,7 +10,7 @@ import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 
 /**
- * Created by TGI on 20.03.2015.
+ *  Demo service endpoint for receiving message of HttpConnector.
  */
 public class DemoHttpServer {
 

--- a/integration-test/general/src/test/java/io/tracee/contextlogger/integrationtest/ImplicitContextIntegrationTest.java
+++ b/integration-test/general/src/test/java/io/tracee/contextlogger/integrationtest/ImplicitContextIntegrationTest.java
@@ -3,6 +3,8 @@ package io.tracee.contextlogger.integrationtest;
 import io.tracee.contextlogger.TraceeContextLogger;
 import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
 import io.tracee.contextlogger.contextprovider.api.Profile;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
+import io.tracee.contextlogger.integrationtest.testcontextprovider.TestImplicitContextProviders;
 import io.tracee.contextlogger.outputgenerator.writer.BasicOutputWriterConfiguration;
 import io.tracee.contextlogger.util.test.RegexMatcher;
 import org.hamcrest.MatcherAssert;
@@ -25,7 +27,7 @@ public class ImplicitContextIntegrationTest {
 	@Test
 	public void shouldOutputImplicitContextCorrectly() {
 		String result = TraceeContextLogger.create().enforceOutputWriterConfiguration(BasicOutputWriterConfiguration.JSON_INLINE)
-				.enforceProfile(Profile.BASIC).apply().toString(ImplicitContext.COMMON, ImplicitContext.TRACEE);
+				.enforceProfile(Profile.BASIC).apply().toString(CoreImplicitContextProviders.COMMON, CoreImplicitContextProviders.TRACEE);
 
 		MatcherAssert.assertThat(result, RegexMatcher.matches("\\[\"TYPE:Object\\[]\",\\{\"TYPE\":\"common\".*"));
 	}
@@ -35,7 +37,7 @@ public class ImplicitContextIntegrationTest {
 
 
 		String result = TraceeContextLogger.create().enforceOutputWriterConfiguration(BasicOutputWriterConfiguration.JSON_INLINE)
-				.enforceProfile(Profile.BASIC).apply().toString(ImplicitContext.TRACEE);
+				.enforceProfile(Profile.BASIC).apply().toString(CoreImplicitContextProviders.TRACEE);
 
 		MatcherAssert.assertThat(result, Matchers.is("{\"TYPE\":\"tracee\",\"DYNAMIC\":null}"));
 	}
@@ -52,6 +54,15 @@ public class ImplicitContextIntegrationTest {
 		String result = TraceeContextLogger.create().enforceProfile(Profile.BASIC).apply().toString(this);
 
 		MatcherAssert.assertThat(result, Matchers.is("\"ImplicitContextIntegrationTest[]\""));
+	}
+
+	@Test
+	public void should_write_test_and_core_implicit_context_providers() {
+
+		String result = TraceeContextLogger.create().enforceProfile(Profile.FULL).apply().toString(CoreImplicitContextProviders.TRACEE, TestImplicitContextProviders.TEST);
+
+		MatcherAssert.assertThat(result, Matchers.containsString("tracee"));
+		MatcherAssert.assertThat(result, Matchers.containsString("testImplicitContextData"));
 	}
 
 }

--- a/integration-test/general/src/test/java/io/tracee/contextlogger/integrationtest/MdcContextLoggerTest.java
+++ b/integration-test/general/src/test/java/io/tracee/contextlogger/integrationtest/MdcContextLoggerTest.java
@@ -1,64 +1,63 @@
 package io.tracee.contextlogger.integrationtest;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-
+import io.tracee.contextlogger.TraceeToStringBuilder;
+import io.tracee.contextlogger.contextprovider.core.CoreImplicitContextProviders;
+import io.tracee.contextlogger.contextprovider.core.utility.NameValuePair;
+import io.tracee.contextlogger.outputgenerator.writer.BasicOutputWriterConfiguration;
 import org.junit.Test;
 import org.slf4j.MDC;
 
-import io.tracee.contextlogger.TraceeToStringBuilder;
-import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
-import io.tracee.contextlogger.contextprovider.core.utility.NameValuePair;
-import io.tracee.contextlogger.outputgenerator.writer.BasicOutputWriterConfiguration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  *
  */
 public class MdcContextLoggerTest {
 
-    private MdcContextLoggerTest cycle1 = this;
-    private MdcContextLoggerTest cycle2 = this;
-    private String field = "FIELD";
-    private List<String> list = new ArrayList<String>();
+	private MdcContextLoggerTest cycle1 = this;
+	private MdcContextLoggerTest cycle2 = this;
+	private String field = "FIELD";
+	private List<String> list = new ArrayList<String>();
 
-    public List<String> getList() {
-        return list;
-    }
+	public List<String> getList() {
+		return list;
+	}
 
-    public String getField() {
-        return field;
-    }
+	public String getField() {
+		return field;
+	}
 
-    {
-        Collections.addAll(list, "ABC", "DEF");
+	{
+		Collections.addAll(list, "ABC", "DEF");
 
-    }
+	}
 
-    public MdcContextLoggerTest getCycle1() {
-        return cycle1;
-    }
+	public MdcContextLoggerTest getCycle1() {
+		return cycle1;
+	}
 
-    public MdcContextLoggerTest getCycle2() {
-        return cycle2;
-    }
+	public MdcContextLoggerTest getCycle2() {
+		return cycle2;
+	}
 
-    @Test
-    public void test_should_use_mdc_logger_correctly() {
+	@Test
+	public void test_should_use_mdc_logger_correctly() {
 
-        MDC.put("KEY", "VALUE");
+		MDC.put("KEY", "VALUE");
 
-        NameValuePair<String> nvPair = new NameValuePair<String>("NVPAIR", "VALUE");
+		NameValuePair<String> nvPair = new NameValuePair<String>("NVPAIR", "VALUE");
 
-        TraceeToStringBuilder.createDefault().toString("ABC", "DEF");
-        // TraceeToStringBuilder.create().enforceOutputWriterConfiguration(BasicOutputWriterConfiguration.JSON_INTENDED).enforceProfile(Profile.FULL).disableTypes(TypeX.class).apply().toString("ABC",
-        // "DEF");
+		TraceeToStringBuilder.createDefault().toString("ABC", "DEF");
+		// TraceeToStringBuilder.create().enforceOutputWriterConfiguration(BasicOutputWriterConfiguration.JSON_INTENDED).enforceProfile(Profile.FULL).disableTypes(TypeX.class).apply().toString("ABC",
+		// "DEF");
 
-        System.out.println(TraceeToStringBuilder.create().enforceOrder().apply()
-                .toString("ABC", new NullPointerException(), ImplicitContext.TRACEE, this, ImplicitContext.COMMON));
+		System.out.println(TraceeToStringBuilder.create().enforceOrder().apply()
+				.toString("ABC", new NullPointerException(), CoreImplicitContextProviders.TRACEE, this, CoreImplicitContextProviders.COMMON));
 
-        System.out.println(TraceeToStringBuilder.create().enforceOutputWriterConfiguration(BasicOutputWriterConfiguration.JSON_INLINE)
-                .disableTypes(MdcContextLoggerTest.class).apply().wrap("ABC", this, ImplicitContext.COMMON, ImplicitContext.TRACEE));
+		System.out.println(TraceeToStringBuilder.create().enforceOutputWriterConfiguration(BasicOutputWriterConfiguration.JSON_INLINE)
+				.disableTypes(MdcContextLoggerTest.class).apply().wrap("ABC", this, CoreImplicitContextProviders.COMMON, CoreImplicitContextProviders.TRACEE));
 
-    }
+	}
 }

--- a/integration-test/testcontextprovider/src/main/java/io/tracee/contextlogger/integrationtest/testcontextprovider/BrokenContextProviderThatThrowsNullPointerException.java
+++ b/integration-test/testcontextprovider/src/main/java/io/tracee/contextlogger/integrationtest/testcontextprovider/BrokenContextProviderThatThrowsNullPointerException.java
@@ -1,6 +1,6 @@
 package io.tracee.contextlogger.integrationtest.testcontextprovider;
 
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
@@ -9,7 +9,7 @@ import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
  * Broken context data wrapper that throws a NullPointerException at deserialization.
  */
 @TraceeContextProvider(displayName = "brokenCustomContextDataWrapper", order = 50)
-@ProfileSettings(basic = true, enhanced = true)
+@ProfileConfig(basic = true, enhanced = true)
 public class BrokenContextProviderThatThrowsNullPointerException implements WrappedContextData<WrappedBrokenTestContextData> {
 
 	public static final String PROPERTY_NAME = "io.tracee.contextlogger.integrationtest.BrokenCustomContextDataWrapper.output";
@@ -41,7 +41,7 @@ public class BrokenContextProviderThatThrowsNullPointerException implements Wrap
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "testoutput", order = 10)
-	@ProfileSettings(basic = false, enhanced = true)
+	@ProfileConfig(basic = false, enhanced = true)
 	public String getOutput() {
 		throw new NullPointerException("Whoops!!!");
 	}

--- a/integration-test/testcontextprovider/src/main/java/io/tracee/contextlogger/integrationtest/testcontextprovider/BrokenImplicitContextProviderThatThrowsNullPointerException.java
+++ b/integration-test/testcontextprovider/src/main/java/io/tracee/contextlogger/integrationtest/testcontextprovider/BrokenImplicitContextProviderThatThrowsNullPointerException.java
@@ -2,7 +2,7 @@ package io.tracee.contextlogger.integrationtest.testcontextprovider;
 
 import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
 import io.tracee.contextlogger.contextprovider.api.ImplicitContextData;
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 
@@ -10,21 +10,21 @@ import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
  * Test provider that provides implicit context information that triggers an exception during deserialization.
  */
 @TraceeContextProvider(displayName = "testBrokenImplicitContextData", order = 200)
-@ProfileSettings(basic = true, enhanced = true)
+@ProfileConfig(basic = true, enhanced = true)
 public class BrokenImplicitContextProviderThatThrowsNullPointerException implements ImplicitContextData {
 
 	public static final String PROPERTY_NAME = "io.tracee.contextlogger.integrationtest.TestBrokenImplicitContextDataProvider.output";
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "output", order = 10)
-	@ProfileSettings(basic = true, enhanced = true)
+	@ProfileConfig(basic = true, enhanced = true)
 	public final String getOutput() {
 		throw new NullPointerException("Whoops!!!");
 	}
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "workingOutput", order = 20)
-	@ProfileSettings(basic = true, enhanced = true)
+	@ProfileConfig(basic = true, enhanced = true)
 	public final String getWorkingOutput() {
 		return "IT_WORKS";
 	}

--- a/integration-test/testcontextprovider/src/main/java/io/tracee/contextlogger/integrationtest/testcontextprovider/TestContextDataWrapper.java
+++ b/integration-test/testcontextprovider/src/main/java/io/tracee/contextlogger/integrationtest/testcontextprovider/TestContextDataWrapper.java
@@ -1,6 +1,6 @@
 package io.tracee.contextlogger.integrationtest.testcontextprovider;
 
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
@@ -9,7 +9,7 @@ import io.tracee.contextlogger.contextprovider.api.WrappedContextData;
  * Test wrapper class that wraps type {@link io.tracee.contextlogger.integrationtest.WrappedTestContextData}.
  */
 @TraceeContextProvider(displayName = "testdata", order = 50)
-@ProfileSettings(basic = true, enhanced = true, full = true)
+@ProfileConfig(basic = true, enhanced = true, full = true)
 public class TestContextDataWrapper implements WrappedContextData<WrappedTestContextData> {
 
 	public static final String PROPERTY_NAME = "io.tracee.contextlogger.integrationtest.testcontextprovider.TestContextDataWrapper.output";
@@ -41,7 +41,7 @@ public class TestContextDataWrapper implements WrappedContextData<WrappedTestCon
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "testoutput", order = 10)
-	@ProfileSettings(basic = false, enhanced = true, full = true)
+	@ProfileConfig(basic = false, enhanced = true, full = true)
 	public String getOutput() {
 		return contextData != null ? contextData.getOutput() : null;
 	}

--- a/integration-test/testcontextprovider/src/main/java/io/tracee/contextlogger/integrationtest/testcontextprovider/TestImplicitContextProvider.java
+++ b/integration-test/testcontextprovider/src/main/java/io/tracee/contextlogger/integrationtest/testcontextprovider/TestImplicitContextProvider.java
@@ -3,7 +3,7 @@ package io.tracee.contextlogger.integrationtest.testcontextprovider;
 
 import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
 import io.tracee.contextlogger.contextprovider.api.ImplicitContextData;
-import io.tracee.contextlogger.contextprovider.api.ProfileSettings;
+import io.tracee.contextlogger.contextprovider.api.ProfileConfig;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProvider;
 import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 
@@ -13,7 +13,7 @@ import io.tracee.contextlogger.contextprovider.api.TraceeContextProviderMethod;
 
 
 @TraceeContextProvider(displayName = "testImplicitContextData", order = 200)
-@ProfileSettings(basic = false, enhanced = true)
+@ProfileConfig(basic = false, enhanced = true)
 public class TestImplicitContextProvider implements ImplicitContextData {
 
 
@@ -22,7 +22,7 @@ public class TestImplicitContextProvider implements ImplicitContextData {
 
 	@SuppressWarnings("unused")
 	@TraceeContextProviderMethod(displayName = "output", order = 10)
-	@ProfileSettings(basic = false, enhanced = true)
+	@ProfileConfig(basic = false, enhanced = true)
 	public final String getOutput() {
 		return OUTPUT;
 	}

--- a/integration-test/testcontextprovider/src/main/java/io/tracee/contextlogger/integrationtest/testcontextprovider/TestImplicitContextProvider.java
+++ b/integration-test/testcontextprovider/src/main/java/io/tracee/contextlogger/integrationtest/testcontextprovider/TestImplicitContextProvider.java
@@ -29,7 +29,7 @@ public class TestImplicitContextProvider implements ImplicitContextData {
 
 	@Override
 	public ImplicitContext getImplicitContext() {
-		return null;
+		return TestImplicitContextProviders.TEST;
 	}
 }
 

--- a/integration-test/testcontextprovider/src/main/java/io/tracee/contextlogger/integrationtest/testcontextprovider/TestImplicitContextProviders.java
+++ b/integration-test/testcontextprovider/src/main/java/io/tracee/contextlogger/integrationtest/testcontextprovider/TestImplicitContextProviders.java
@@ -1,0 +1,19 @@
+package io.tracee.contextlogger.integrationtest.testcontextprovider;
+
+import io.tracee.contextlogger.contextprovider.api.ImplicitContext;
+
+/**
+ * Enum for adding implicit test contextproviders.
+ */
+public enum TestImplicitContextProviders implements ImplicitContext {
+
+	BROKEN(BrokenImplicitContextProviderThatThrowsNullPointerException.class),
+	TEST(TestImplicitContextProvider.class);
+
+	private final Class implicitContextProviderClass;
+
+	private TestImplicitContextProviders(final Class implicitContextProviderClass) {
+		this.implicitContextProviderClass = implicitContextProviderClass;
+	}
+
+}


### PR DESCRIPTION
- [#46] ImplicitContextProviders generally can be added to string representation builder output by using enum mapping values.
- [#22] Test coverage was increased by adding additional tests.
- Renamed ProfileSettings annotation to ProfileConfig, because class name was used twice in project.